### PR TITLE
fix(ci): allow auto assign on pull requests

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   assign:


### PR DESCRIPTION
## Summary
- grant pull request write permission to the auto-assign workflow
- fixes the 403 failure when assigning maintainers on pull_request_target events

## Testing
- git diff --check