### PR TITLE
ci(release): update goreleaser action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "RELEASE_VERSION=${TAG#v}" >> "$GITHUB_ENV"
 
       - name: Build release artifacts
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary
- update GoReleaser action to v7 so release workflows no longer need the Node 20 compatibility path

## Verification
- git diff --check