### PR TITLE
fix(api): dedupe Notion rich text titles

### DIFF
--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -32,7 +32,7 @@ func TestSyncIngestsDatabasesAndRows(t *testing.T) {
 					"results":[{
 						"object":"database",
 						"id":"db1",
-						"title":[{"plain_text":"Roadmap"}],
+						"title":[{"type":"text","plain_text":"Roadmap","text":{"content":"Roadmap"}}],
 						"parent":{"type":"workspace","workspace":true},
 						"properties":{
 							"Name":{"id":"title","type":"title","title":{}},
@@ -57,7 +57,7 @@ func TestSyncIngestsDatabasesAndRows(t *testing.T) {
 					"url":"https://notion.so/page1",
 					"parent":{"type":"database_id","database_id":"db1"},
 					"properties":{
-						"Name":{"id":"title","type":"title","title":[{"plain_text":"Ship"}]},
+						"Name":{"id":"title","type":"title","title":[{"type":"text","plain_text":"Ship","text":{"content":"Ship"}}]},
 						"Status":{"id":"status","type":"select","select":{"name":"Done"}}
 					}
 				}],
@@ -93,7 +93,7 @@ func TestSyncIngestsDatabasesAndRows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 1 || rows[0].ID != "page1" || rows[0].CollectionID != "db1" {
+	if len(rows) != 1 || rows[0].ID != "page1" || rows[0].CollectionID != "db1" || rows[0].Title != "Ship" {
 		t.Fatalf("unexpected rows: %+v", rows)
 	}
 }
@@ -122,7 +122,7 @@ func TestSyncIngestsCurrentDataSourcesAndRows(t *testing.T) {
 					"results":[{
 						"object":"data_source",
 						"id":"ds1",
-						"title":[{"plain_text":"Roadmap"}],
+						"title":[{"type":"text","plain_text":"Roadmap","text":{"content":"Roadmap"}}],
 						"parent":{"type":"database_id","database_id":"db1"},
 						"database_parent":{"type":"page_id","page_id":"page-parent"},
 						"properties":{
@@ -147,7 +147,7 @@ func TestSyncIngestsCurrentDataSourcesAndRows(t *testing.T) {
 					"url":"https://notion.so/page1",
 					"parent":{"type":"data_source_id","data_source_id":"ds1"},
 					"properties":{
-						"Name":{"id":"title","type":"title","title":[{"plain_text":"Ship"}]},
+						"Name":{"id":"title","type":"title","title":[{"type":"text","plain_text":"Ship","text":{"content":"Ship"}}]},
 						"Status":{"id":"status","type":"select","select":{"name":"Done"}}
 					}
 				}],
@@ -176,14 +176,14 @@ func TestSyncIngestsCurrentDataSourcesAndRows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(collections) != 1 || collections[0].ID != "ds1" || collections[0].ParentID != "db1" {
+	if len(collections) != 1 || collections[0].ID != "ds1" || collections[0].ParentID != "db1" || collections[0].Name != "Roadmap" {
 		t.Fatalf("unexpected collections: %+v", collections)
 	}
 	rows, err := st.CollectionPages(context.Background(), "ds1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 1 || rows[0].ID != "page1" || rows[0].CollectionID != "ds1" {
+	if len(rows) != 1 || rows[0].ID != "page1" || rows[0].CollectionID != "ds1" || rows[0].Title != "Ship" {
 		t.Fatalf("unexpected rows: %+v", rows)
 	}
 }

--- a/internal/notiontext/text.go
+++ b/internal/notiontext/text.go
@@ -131,19 +131,42 @@ func walk(v any, parts *[]string) {
 			walk(item, parts)
 		}
 	case map[string]any:
-		for _, key := range []string{"plain_text", "content", "text", "name", "title"} {
+		if text, ok := normalizedString(x["plain_text"]); ok {
+			*parts = append(*parts, text)
+			return
+		}
+		if text, ok := richTextContent(x["text"]); ok {
+			*parts = append(*parts, text)
+			return
+		}
+		if text, ok := normalizedString(x["content"]); ok {
+			*parts = append(*parts, text)
+			return
+		}
+		for _, key := range []string{"name", "title", "rich_text", "text"} {
 			if value, ok := x[key]; ok {
 				walk(value, parts)
 			}
 		}
-		if rt, ok := x["rich_text"]; ok {
-			walk(rt, parts)
-		}
-		if title, ok := x["title"]; ok {
-			walk(title, parts)
-		}
-		if text, ok := x["text"].(map[string]any); ok {
-			walk(text["content"], parts)
-		}
 	}
+}
+
+func richTextContent(v any) (string, bool) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	return normalizedString(m["content"])
+}
+
+func normalizedString(v any) (string, bool) {
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	s = Normalize(s)
+	if s == "" {
+		return "", false
+	}
+	return s, true
 }

--- a/internal/notiontext/text_test.go
+++ b/internal/notiontext/text_test.go
@@ -9,6 +9,62 @@ func TestTitleFromProperties(t *testing.T) {
 	}
 }
 
+func TestTitleFromPropertiesPrefersNotionRichTextOnce(t *testing.T) {
+	got := TitleFromProperties(`{
+		"Name": {
+			"id": "title",
+			"type": "title",
+			"title": [{
+				"type": "text",
+				"plain_text": "OpenClaw",
+				"text": {"content": "OpenClaw"}
+			}]
+		}
+	}`)
+	if got != "OpenClaw" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestPlainPrefersNotionRichTextPlainTextOnce(t *testing.T) {
+	got := Plain([]any{map[string]any{
+		"type":       "text",
+		"plain_text": "OpenClaw",
+		"text": map[string]any{
+			"content": "OpenClaw",
+		},
+	}})
+	if got != "OpenClaw" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestPlainFallsBackToNotionTextContentOnce(t *testing.T) {
+	got := Plain([]any{map[string]any{
+		"type": "text",
+		"text": map[string]any{
+			"content": "OpenClaw",
+		},
+	}})
+	if got != "OpenClaw" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestPlainWalksTitleOnlyOnce(t *testing.T) {
+	got := Plain(map[string]any{
+		"title": []any{map[string]any{
+			"plain_text": "Roadmap",
+			"text": map[string]any{
+				"content": "Roadmap",
+			},
+		}},
+	})
+	if got != "Roadmap" {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestSlug(t *testing.T) {
 	got := Slug("Launch Plan / Q2")
 	if got != "launch-plan-q2" {


### PR DESCRIPTION
## Summary

- make Notion rich text extraction choose the canonical visible text once instead of walking equivalent fields repeatedly
- add regression coverage for API title/rich_text payloads that include both `plain_text` and `text.content`
- update API ingest fixtures so page and data-source titles use the real Notion rich text shape

## Root Cause

`notiontext.Plain` recursively walked `plain_text`, `text`, `title`, and `text.content` on the same Notion rich text object. API title objects commonly include both `plain_text` and `text.content`, so titles were stored as repeated strings and then surfaced in search, database listings, front matter, and markdown filenames.

Fixes #19

## Validation

- `go test ./...`
- `go build -o /tmp/notcrawl-title-dedupe ./cmd/notcrawl`
- live read-only Notion API probe confirmed page/data-source payloads expose equivalent `plain_text` and `text.content` fields
- temp API sync reached 223 pages before Notion returned a retryable Cloudflare 502 from `/comments`; exported partial data had no repeated page titles or markdown title slugs
