### PR TITLE
fix(export): clean emoji from filenames

### DIFF
--- a/cmd/notcrawl/main_test.go
+++ b/cmd/notcrawl/main_test.go
@@ -29,7 +29,7 @@ func TestExportDatabaseAllWritesFilesAndIndex(t *testing.T) {
 	now := store.NowMS()
 	for _, collection := range []store.Collection{
 		{ID: "db1", Name: "Roadmap", Source: "test", SyncedAt: now, SchemaJSON: `{"Name":{"type":"title"}}`},
-		{ID: "db2", Name: "Launch Plan", Source: "test", SyncedAt: now, SchemaJSON: `{"Task":{"type":"title"}}`},
+		{ID: "db2", Name: "Launch 🚀 Plan ✅", Source: "test", SyncedAt: now, SchemaJSON: `{"Task":{"type":"title"}}`},
 	} {
 		if err := st.UpsertCollection(ctx, collection); err != nil {
 			t.Fatal(err)

--- a/internal/markdown/export_test.go
+++ b/internal/markdown/export_test.go
@@ -79,7 +79,7 @@ func TestExporterUsesDisplayOrder(t *testing.T) {
 	}
 }
 
-func TestExporterPreservesUnicodePathNames(t *testing.T) {
+func TestExporterRemovesEmojiFromPathNames(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
 	if err != nil {
@@ -99,7 +99,7 @@ func TestExporterPreservesUnicodePathNames(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join(dir, "研究-🚀", "計画-✅-q2-page1.md")
+	want := filepath.Join(dir, "研究", "計画-q2-page1.md")
 	if len(s.Files) != 1 || s.Files[0] != want {
 		t.Fatalf("unexpected export path: %+v, want %s", s.Files, want)
 	}

--- a/internal/notiontext/text.go
+++ b/internal/notiontext/text.go
@@ -103,7 +103,7 @@ func Slug(s string) string {
 }
 
 func isSlugRune(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsNumber(r) || unicode.IsMark(r) || (r > unicode.MaxASCII && unicode.IsSymbol(r)) || r == '\u200d'
+	return unicode.IsLetter(r) || unicode.IsNumber(r)
 }
 
 func isSlugSeparator(r rune) bool {

--- a/internal/notiontext/text_test.go
+++ b/internal/notiontext/text_test.go
@@ -72,9 +72,9 @@ func TestSlug(t *testing.T) {
 	}
 }
 
-func TestSlugPreservesUnicodePathText(t *testing.T) {
+func TestSlugRemovesEmojiPathText(t *testing.T) {
 	got := Slug("研究 🚀 / 計画 ✅")
-	if got != "研究-🚀-計画-✅" {
+	if got != "研究-計画" {
 		t.Fatalf("got %q", got)
 	}
 }
@@ -82,6 +82,13 @@ func TestSlugPreservesUnicodePathText(t *testing.T) {
 func TestSlugRemovesUnsafePathText(t *testing.T) {
 	got := Slug(`A/B\C:D*E?F"G<H>I|J`)
 	if got != "a-b-c-d-e-f-g-h-i-j" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSlugRemovesEmojiVariationSelectors(t *testing.T) {
+	got := Slug("⚠️ Production Incident Guide")
+	if got != "production-incident-guide" {
 		t.Fatalf("got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- stop preserving emoji, symbols, zero-width joiners, and variation selectors in export slugs
- keep readable letter/number path text while normalizing separators to dashes
- cover markdown and bulk CSV filenames with emoji-heavy test cases

## Verification
- `go test ./internal/notiontext ./internal/markdown ./cmd/notcrawl`
- `go test ./...`
- local export: 4,343 markdown files, 218 CSV files, 3,049 CSV rows
- filename scan: `bad_filename_count=0` for emoji/symbol ranges across generated markdown and CSV filenames