### PR TITLE
fix(release): publish formula to Homebrew tap

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout tap repository
         uses: actions/checkout@v5
         with:
-          repository: ${{ vars.HOMEBREW_TAP_REPO || 'vincentkoc/tap' }}
+          repository: ${{ vars.HOMEBREW_TAP_REPO || 'vincentkoc/homebrew-tap' }}
           token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       - name: Update formula


### PR DESCRIPTION
## Summary
- publish the generated formula to `vincentkoc/homebrew-tap`, which is the repository Homebrew uses for `brew tap vincentkoc/tap`
- keep the repository override via `HOMEBREW_TAP_REPO`, but fix the default target

Fixes #25

## Verification
- parsed `.github/workflows/homebrew-tap.yml` as YAML
- confirmed `vincentkoc/homebrew-tap` currently lacks `Formula/notcrawl.rb`
- confirmed the old target `vincentkoc/tap` has the misplaced `Formula/notcrawl.rb`