### PR TITLE
Fix UTF-8 truncation in markdown export paths

### DIFF
--- a/internal/markdown/export.go
+++ b/internal/markdown/export.go
@@ -348,7 +348,14 @@ func maxSlug(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	s = strings.TrimRight(s[:max], "-")
+	cut := 0
+	for i := range s {
+		if i > max {
+			break
+		}
+		cut = i
+	}
+	s = strings.TrimRight(s[:cut], "-")
 	if s == "" {
 		return "untitled"
 	}

--- a/internal/markdown/export_test.go
+++ b/internal/markdown/export_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/vincentkoc/notcrawl/internal/store"
 )
@@ -102,6 +103,36 @@ func TestExporterRemovesEmojiFromPathNames(t *testing.T) {
 	want := filepath.Join(dir, "研究", "計画-q2-page1.md")
 	if len(s.Files) != 1 || s.Files[0] != want {
 		t.Fatalf("unexpected export path: %+v, want %s", s.Files, want)
+	}
+}
+
+func TestExporterTruncatesMultibytePathNamesOnRuneBoundary(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	title := "где-у-меня-записаны-соображения-по-поводу-аллокации-затрат-на-подрядчиков-и-других-расходов"
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: title, Alive: true, Source: "test", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	s, err := Exporter{Store: st, Dir: dir}.Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Files) != 1 {
+		t.Fatalf("unexpected export paths: %+v", s.Files)
+	}
+	name := filepath.Base(s.Files[0])
+	if !utf8.ValidString(name) {
+		t.Fatalf("export path is not valid UTF-8: %q", name)
+	}
+	if _, err := os.Stat(s.Files[0]); err != nil {
+		t.Fatalf("exported file missing: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- truncate markdown export slugs only at UTF-8 rune boundaries
- add regression coverage for long Cyrillic page titles on macOS paths

## Verification
- go test ./internal/markdown -run TestExporterTruncatesMultibytePathNamesOnRuneBoundary -count=1
- go test ./...
- go run ./cmd/notcrawl export-md