### PR TITLE
feat: improve Notion archive completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## 0.4.1 - Unreleased
+## 0.5.0 - Unreleased
 
-- Update `crawlkit` to v0.7.0.
+- Mark incomplete Desktop-cache Markdown pages with missing-block metadata and warnings instead of silently exporting title-only files.
+- Render page and database-row properties in Markdown exports with collection schema labels when available.
+- Preserve previously cached Desktop pages and blocks across opportunistic cache eviction while honoring explicit tombstones.
+- Track API and Desktop provenance independently so archived API records restore live Desktop page, block, and comment payloads.
+- Preserve source provenance in git-share snapshots and validate complete manifests before replacing a local archive.
+- Update `crawlkit` to v0.11.0.
 - API sync now tolerates Notion `restricted_resource` failures from `/users`, continues page/database discovery without user labels, and warns when API discovery returns no pages, databases, blocks, or comments. Thanks @elijahmuraoka.
 - API sync now skips fetching copied synced-block children that Notion reports as `object_not_found`, while still storing the synced-block copy. Thanks @elijahmuraoka.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ See [`docs/distribution.md`](docs/distribution.md) for release operations.
 ## Safety Model
 
 Desktop mode is read-only. It snapshots Notion's local SQLite database before
-reading it and never writes to Notion application storage.
+reading it and never writes to Notion application storage. Desktop cache
+coverage is opportunistic; Markdown exports mark pages whose referenced blocks
+were not cached locally, and API sync can fill content shared with an integration.
+Rows missing from a later Desktop snapshot are preserved because cache eviction
+is not a deletion signal; explicit Notion tombstones still retire records.
 
 API mode uses the official Notion API. It stores raw API payloads alongside
 normalized rows so renderers can improve without recrawling.

--- a/cmd/notcrawl/main.go
+++ b/cmd/notcrawl/main.go
@@ -521,7 +521,11 @@ func runExportMarkdown(ctx context.Context, stdout io.Writer, cfg config.Config)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "exported %d pages to %s\n", s.Pages, cfg.MarkdownDir)
+	fmt.Fprintf(stdout, "exported %d pages to %s", s.Pages, cfg.MarkdownDir)
+	if s.IncompletePages > 0 {
+		fmt.Fprintf(stdout, " (%d incomplete; %d missing block references)", s.IncompletePages, s.MissingBlockReferences)
+	}
+	fmt.Fprintln(stdout)
 	return nil
 }
 

--- a/internal/markdown/export.go
+++ b/internal/markdown/export.go
@@ -2,6 +2,7 @@ package markdown
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -13,7 +14,19 @@ import (
 
 	"github.com/openclaw/notcrawl/internal/notiontext"
 	"github.com/openclaw/notcrawl/internal/store"
+	"github.com/openclaw/notcrawl/internal/tableexport"
 )
+
+type propertySpec struct {
+	Name string
+	Type string
+}
+
+type propertyRow struct {
+	key   string
+	name  string
+	value string
+}
 
 type Exporter struct {
 	Store *store.Store
@@ -21,8 +34,10 @@ type Exporter struct {
 }
 
 type Summary struct {
-	Pages int
-	Files []string
+	Pages                  int
+	IncompletePages        int
+	MissingBlockReferences int
+	Files                  []string
 }
 
 func (e Exporter) Export(ctx context.Context) (Summary, error) {
@@ -46,12 +61,16 @@ func (e Exporter) Export(ctx context.Context) (Summary, error) {
 	var s Summary
 	keep := map[string]bool{}
 	for _, page := range pages {
-		path, err := e.writePage(ctx, paths, page)
+		path, coverage, err := e.writePage(ctx, paths, page)
 		if err != nil {
 			return s, err
 		}
 		keep[filepath.Clean(path)] = true
 		s.Pages++
+		if coverage.Missing > 0 {
+			s.IncompletePages++
+			s.MissingBlockReferences += coverage.Missing
+		}
 		s.Files = append(s.Files, path)
 	}
 	if err := pruneStaleMarkdown(e.Dir, keep); err != nil {
@@ -60,17 +79,32 @@ func (e Exporter) Export(ctx context.Context) (Summary, error) {
 	return s, nil
 }
 
-func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.Page) (string, error) {
+func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.Page) (string, store.BlockCoverage, error) {
 	spaceName := paths.spaceName(page.SpaceID)
 	teamID := paths.pageTeamID(page)
 	teamName := paths.teamName(teamID)
 	blocks, err := e.Store.PageBlocks(ctx, page.ID)
 	if err != nil {
-		return "", err
+		return "", store.BlockCoverage{}, err
+	}
+	var coverage store.BlockCoverage
+	apiBlocksSynced, err := e.Store.HasSyncState(ctx, "api", "page_blocks", page.ID)
+	if err != nil {
+		return "", store.BlockCoverage{}, err
+	}
+	desktopBacked, err := e.Store.RecordHasLiveSource(ctx, "page", page.ID, "desktop")
+	if err != nil {
+		return "", store.BlockCoverage{}, err
+	}
+	if desktopBacked && !apiBlocksSynced {
+		coverage, err = e.Store.PageBlockCoverage(ctx, page.ID)
+		if err != nil {
+			return "", store.BlockCoverage{}, err
+		}
 	}
 	comments, err := e.Store.PageComments(ctx, page.ID)
 	if err != nil {
-		return "", err
+		return "", store.BlockCoverage{}, err
 	}
 	spaceSlug := notiontext.Slug(spaceName)
 	titleSlug := maxSlug(notiontext.Slug(page.Title), 96)
@@ -82,14 +116,21 @@ func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.
 	parts = append(parts, name)
 	path := filepath.Join(parts...)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return "", err
+		return "", store.BlockCoverage{}, err
 	}
 	var b strings.Builder
-	writeFrontMatter(&b, page, spaceName, teamID, teamName)
+	writeFrontMatter(&b, page, spaceName, teamID, teamName, coverage)
 	if page.Title != "" {
 		fmt.Fprintf(&b, "# %s\n\n", notiontext.MarkdownEscape(page.Title))
 	}
+	writeCoverageWarning(&b, coverage)
+	wroteProperties := writeProperties(&b, paths, page)
+	beforeBlocks := b.Len()
 	renderBlocks(&b, page.ID, blocks)
+	wroteBlocks := b.Len() > beforeBlocks
+	if shouldWriteEmptyDesktopNotice(page, comments, wroteProperties, wroteBlocks) {
+		b.WriteString("> [!NOTE]\n> No body blocks or non-title properties were present in the Desktop cache. The page may be empty or its body may not have been cached.\n\n")
+	}
 	if len(comments) > 0 {
 		if !strings.HasSuffix(b.String(), "\n\n") {
 			b.WriteString("\n")
@@ -104,14 +145,16 @@ func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.
 		}
 	}
 	out := strings.TrimRight(b.String(), " \n") + "\n"
-	return path, os.WriteFile(path, []byte(out), 0o644)
+	return path, coverage, os.WriteFile(path, []byte(out), 0o644)
 }
 
 type pathResolver struct {
-	spaces      map[string]string
-	teams       map[string]string
-	blocks      map[string]store.ParentRef
-	collections map[string]store.ParentRef
+	spaces       map[string]string
+	teams        map[string]string
+	blocks       map[string]store.ParentRef
+	collections  map[string]store.ParentRef
+	properties   map[string]map[string]propertySpec
+	propertyRefs tableexport.ReferenceLabels
 }
 
 func newPathResolver(ctx context.Context, st *store.Store) (pathResolver, error) {
@@ -131,7 +174,33 @@ func newPathResolver(ctx context.Context, st *store.Store) (pathResolver, error)
 	if err != nil {
 		return pathResolver{}, err
 	}
-	return pathResolver{spaces: spaces, teams: teams, blocks: blocks, collections: collections}, nil
+	collectionRows, err := st.Collections(ctx)
+	if err != nil {
+		return pathResolver{}, err
+	}
+	properties := make(map[string]map[string]propertySpec, len(collectionRows))
+	for _, collection := range collectionRows {
+		properties[collection.ID] = propertySpecs(collection.SchemaJSON)
+	}
+	users, err := st.UserNames(ctx)
+	if err != nil {
+		return pathResolver{}, err
+	}
+	pages, err := st.PageTitles(ctx)
+	if err != nil {
+		return pathResolver{}, err
+	}
+	return pathResolver{
+		spaces:      spaces,
+		teams:       teams,
+		blocks:      blocks,
+		collections: collections,
+		properties:  properties,
+		propertyRefs: tableexport.ReferenceLabels{
+			Users: users,
+			Pages: pages,
+		},
+	}, nil
 }
 
 func (r pathResolver) spaceName(id string) string {
@@ -181,7 +250,7 @@ func (r pathResolver) resolveTeamID(table, id, collectionID string, seen map[str
 	}
 }
 
-func writeFrontMatter(b *strings.Builder, page store.Page, spaceName, teamID, teamName string) {
+func writeFrontMatter(b *strings.Builder, page store.Page, spaceName, teamID, teamName string, coverage store.BlockCoverage) {
 	b.WriteString("---\n")
 	writeKV(b, "id", page.ID)
 	writeKV(b, "space_id", page.SpaceID)
@@ -193,7 +262,128 @@ func writeFrontMatter(b *strings.Builder, page store.Page, spaceName, teamID, te
 	writeKV(b, "notion_url", page.URL)
 	writeKV(b, "created_time", formatMS(page.CreatedTime))
 	writeKV(b, "last_edited_time", formatMS(page.LastEditedTime))
+	if coverage.Missing > 0 {
+		fmt.Fprintln(b, "content_complete: false")
+		fmt.Fprintf(b, "missing_block_references: %d\n", coverage.Missing)
+	}
 	b.WriteString("---\n\n")
+}
+
+func writeCoverageWarning(b *strings.Builder, coverage store.BlockCoverage) {
+	if coverage.Missing == 0 {
+		return
+	}
+	noun := "blocks were"
+	if coverage.Missing == 1 {
+		noun = "block was"
+	}
+	fmt.Fprintf(b, "> [!WARNING]\n> Incomplete Desktop cache snapshot: %d referenced %s not available locally. API sync can retrieve content shared with a Notion integration.\n\n", coverage.Missing, noun)
+}
+
+func writeProperties(b *strings.Builder, paths pathResolver, page store.Page) bool {
+	var properties map[string]any
+	if err := json.Unmarshal([]byte(page.PropertiesJSON), &properties); err != nil {
+		return false
+	}
+	specs := paths.properties[pageCollectionID(page)]
+	var rows []propertyRow
+	for key, value := range properties {
+		spec := specs[key]
+		text := tableexport.PropertyText(value, paths.propertyRefs)
+		if text == "" || strings.Trim(text, "‣ ") == "" {
+			continue
+		}
+		// Without schema/type metadata, preserve ambiguous properties. A duplicate
+		// heading is safer than silently dropping a real field.
+		if spec.Type == "title" || embeddedPropertyType(value) == "title" ||
+			(spec.Type == "" && strings.EqualFold(strings.TrimSpace(key), "title") &&
+				notiontext.Normalize(text) == notiontext.Normalize(page.Title)) {
+			continue
+		}
+		name := spec.Name
+		if name == "" {
+			name = key
+		}
+		rows = append(rows, propertyRow{key: key, name: name, value: text})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		left, right := strings.ToLower(rows[i].name), strings.ToLower(rows[j].name)
+		if left != right {
+			return left < right
+		}
+		if rows[i].name != rows[j].name {
+			return rows[i].name < rows[j].name
+		}
+		return rows[i].key < rows[j].key
+	})
+	if len(rows) == 0 {
+		return false
+	}
+	b.WriteString("## Properties\n\n")
+	for _, row := range rows {
+		fmt.Fprintf(b, "- **%s:** %s\n", markdownPropertyName(row.name), markdownPropertyValue(row.value))
+	}
+	b.WriteString("\n")
+	return true
+}
+
+func markdownPropertyName(name string) string {
+	name = strings.Join(strings.Fields(notiontext.MarkdownEscape(name)), " ")
+	return strings.NewReplacer(
+		`&`, `&amp;`,
+		`<`, `&lt;`,
+		`>`, `&gt;`,
+		`\`, `\\`,
+		`*`, `\*`,
+		`_`, `\_`,
+		`[`, `\[`,
+		`]`, `\]`,
+		"`", "\\`",
+	).Replace(name)
+}
+
+func markdownPropertyValue(value string) string {
+	value = notiontext.MarkdownEscape(value)
+	return strings.ReplaceAll(value, "\n", "<br>")
+}
+
+func shouldWriteEmptyDesktopNotice(page store.Page, comments []store.Comment, wroteProperties, wroteBlocks bool) bool {
+	return strings.Contains(page.Source, "desktop") && !wroteProperties && !wroteBlocks && len(comments) == 0
+}
+
+func propertySpecs(raw string) map[string]propertySpec {
+	var schema map[string]map[string]any
+	if err := json.Unmarshal([]byte(raw), &schema); err != nil {
+		return nil
+	}
+	out := make(map[string]propertySpec, len(schema))
+	for key, value := range schema {
+		name, _ := value["name"].(string)
+		typ, _ := value["type"].(string)
+		out[key] = propertySpec{Name: name, Type: typ}
+	}
+	return out
+}
+
+func pageCollectionID(page store.Page) string {
+	if page.CollectionID != "" {
+		return page.CollectionID
+	}
+	switch page.ParentTable {
+	case "collection", "database", "data_source":
+		return page.ParentID
+	default:
+		return ""
+	}
+}
+
+func embeddedPropertyType(value any) string {
+	property, ok := value.(map[string]any)
+	if !ok {
+		return ""
+	}
+	typ, _ := property["type"].(string)
+	return typ
 }
 
 func writeKV(b *strings.Builder, key, value string) {

--- a/internal/markdown/export_test.go
+++ b/internal/markdown/export_test.go
@@ -80,6 +80,332 @@ func TestExporterUsesDisplayOrder(t *testing.T) {
 	}
 }
 
+func TestExporterMarksMissingDesktopBlocks(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Partial", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	for _, block := range []store.Block{
+		{ID: "page1", PageID: "page1", Type: "page", Text: "Partial", ContentJSON: `["cached","missing","moved"]`, Alive: true, Source: "desktop", SyncedAt: now},
+		{ID: "cached", PageID: "page1", ParentID: "page1", Type: "text", Text: "Available body", Alive: true, Source: "desktop", SyncedAt: now},
+		{ID: "moved", PageID: "other-page", ParentID: "other-page", Type: "text", Text: "Moved body", Alive: true, Source: "desktop", SyncedAt: now},
+		{ID: "detached", PageID: "page1", ParentID: "old-parent", Type: "text", ContentJSON: `["detached-missing"]`, Alive: true, Source: "desktop", SyncedAt: now},
+	} {
+		if err := st.UpsertBlock(ctx, block); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.IncompletePages != 1 || s.MissingBlockReferences != 2 {
+		t.Fatalf("unexpected incomplete summary: %+v", s)
+	}
+	b, err := os.ReadFile(s.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(b)
+	for _, want := range []string{
+		"content_complete: false",
+		"missing_block_references: 2",
+		"Incomplete Desktop cache snapshot: 2 referenced blocks were not available locally.",
+		"Available body",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q from markdown:\n%s", want, text)
+		}
+	}
+}
+
+func TestExporterDoesNotMarkCompleteCachedBlocksIncomplete(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Complete", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	for _, block := range []store.Block{
+		{ID: "page1", PageID: "page1", Type: "page", Text: "Complete", ContentJSON: `["child","subpage"]`, Alive: true, Source: "desktop", SyncedAt: now},
+		{ID: "child", PageID: "page1", ParentID: "page1", Type: "text", Text: "Full body", Alive: true, Source: "desktop", SyncedAt: now},
+		{ID: "subpage", PageID: "subpage", ParentID: "page1", Type: "page", Text: "Nested page", Alive: true, Source: "desktop", SyncedAt: now},
+	} {
+		if err := st.UpsertBlock(ctx, block); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.IncompletePages != 0 || s.MissingBlockReferences != 0 {
+		t.Fatalf("unexpected incomplete summary: %+v", s)
+	}
+	b, err := os.ReadFile(s.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := string(b); strings.Contains(text, "content_complete") || strings.Contains(text, "[!WARNING]") {
+		t.Fatalf("complete page marked incomplete:\n%s", text)
+	}
+}
+
+func TestExporterRendersDatabaseProperties(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertCollection(ctx, store.Collection{
+		ID:         "people",
+		Name:       "People",
+		SchemaJSON: `{"title":{"name":"Name","type":"title"},"people:email":{"name":"Email","type":"email"},"people:membership_type":{"name":"Membership Type","type":"select"},"people:job_title":{"name":"Title","type":"text"},"people:person":{"name":"Person","type":"person"},"owner_upper":{"name":"Owner","type":"text"},"owner_lower":{"name":"owner","type":"text"},"unsafe":{"name":"Risk ** [label]\n# heading","type":"text"}}`,
+		Source:     "desktop",
+		SyncedAt:   now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertUser(ctx, store.User{ID: "user1", Name: "Ada Lovelace", Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, store.Page{
+		ID:             "page1",
+		ParentID:       "people",
+		ParentTable:    "collection",
+		Title:          "Ada",
+		PropertiesJSON: `{"title":[["Ada"]],"people:email":[["ada@example.com"]],"people:membership_type":[["Member"]],"people:job_title":[["Engineer"]],"people:person":[["‣",[["u","user1"]]]],"owner_upper":[["Upper"]],"owner_lower":[["Lower"]],"unsafe":[["Safe"]]}`,
+		Alive:          true,
+		Source:         "desktop",
+		SyncedAt:       now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(s.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(b)
+	for _, want := range []string{"## Properties", "- **Email:** ada@example.com", "- **Membership Type:** Member", "- **Owner:** Upper", "- **owner:** Lower", "- **Person:** Ada Lovelace", "- **Risk \\*\\* \\[label\\] # heading:** Safe", "- **Title:** Engineer"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q from markdown:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "- **Name:**") {
+		t.Fatalf("title property should not be repeated:\n%s", text)
+	}
+	if strings.Index(text, "- **Owner:** Upper") > strings.Index(text, "- **owner:** Lower") {
+		t.Fatalf("case-colliding properties were not deterministic:\n%s", text)
+	}
+}
+
+func TestExporterPreservesSchemaLessProperties(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{
+		ID:             "page1",
+		Title:          "Ship",
+		PropertiesJSON: `{"Task":[["Ship"]],"Name":[["Owner alias"]],"Title":[["Engineer"]]}`,
+		Alive:          true,
+		Source:         "desktop",
+		SyncedAt:       now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(s.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(b)
+	if !strings.Contains(text, "- **Name:** Owner alias") {
+		t.Fatalf("schema-less Name property was dropped:\n%s", text)
+	}
+	if !strings.Contains(text, "- **Task:** Ship") {
+		t.Fatalf("ambiguous schema-less Task property was dropped:\n%s", text)
+	}
+	if !strings.Contains(text, "- **Title:** Engineer") {
+		t.Fatalf("schema-less Title property was dropped:\n%s", text)
+	}
+}
+
+func TestExporterPreservesAmbiguousSchemaLessTitleMatches(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{
+		ID:             "page1",
+		Title:          "Ship",
+		PropertiesJSON: `{"Task":[["Ship"]],"Status":[["Ship"]]}`,
+		Alive:          true,
+		Source:         "desktop",
+		SyncedAt:       now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(s.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(b)
+	for _, want := range []string{"- **Status:** Ship", "- **Task:** Ship"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("ambiguous schema-less property %q was dropped:\n%s", want, text)
+		}
+	}
+}
+
+func TestExporterExplainsEmptyDesktopPage(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Empty or uncached", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{ID: "page1", PageID: "page1", Type: "page", ContentJSON: `["empty-column"]`, Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{ID: "empty-column", PageID: "page1", ParentID: "page1", Type: "column", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(s.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := string(b); !strings.Contains(text, "The page may be empty or its body may not have been cached.") {
+		t.Fatalf("empty Desktop page lacked explanatory note:\n%s", text)
+	}
+}
+
+func TestExporterPreservesAPIPropertyText(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{
+		ID:             "page1",
+		Title:          "API page",
+		PropertiesJSON: `{"Description":{"type":"rich_text","rich_text":[{"type":"text","plain_text":"a https://example.com","text":{"content":"a https://example.com"}}]},"Website":{"type":"url","url":"first line\n# second line"}}`,
+		Alive:          true,
+		Source:         "api",
+		SyncedAt:       now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{
+		ID:          "page1",
+		PageID:      "page1",
+		Type:        "page",
+		ContentJSON: `["stale-missing-child"]`,
+		Alive:       true,
+		Source:      "desktop",
+		SyncedAt:    now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetSyncState(ctx, "api", "page_blocks", "page1", "complete"); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(s.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(b)
+	if !strings.Contains(text, "- **Description:** a https://example.com") {
+		t.Fatalf("API property text was altered:\n%s", text)
+	}
+	if !strings.Contains(text, "- **Website:** first line<br># second line") {
+		t.Fatalf("multiline API property was not kept inline:\n%s", text)
+	}
+	if strings.Contains(text, "content_complete: false") || strings.Contains(text, "Incomplete Desktop cache snapshot") {
+		t.Fatalf("API-refreshed page used stale Desktop coverage:\n%s", text)
+	}
+}
+
+func TestExporterRequiresCompletedAPIBlockSync(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Partial API page", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Partial API page", Alive: true, Source: "api", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{
+		ID: "page1", PageID: "page1", Type: "page", ContentJSON: `["missing-child"]`,
+		Alive: true, Source: "desktop", SyncedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := (Exporter{Store: st, Dir: t.TempDir()}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.IncompletePages != 1 || s.MissingBlockReferences != 1 {
+		t.Fatalf("unfinished API block sync suppressed coverage: %+v", s)
+	}
+}
+
 func TestExporterRemovesEmojiFromPathNames(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -240,13 +240,30 @@ func (c Client) ingestPage(ctx context.Context, st *store.Store, page obj, opts 
 	if p.Title == "" {
 		p.Title = "Untitled"
 	}
+	if opts.FetchBlocks {
+		if err := st.ClearSyncState(ctx, SourceName, "page_blocks", p.ID); err != nil {
+			return 0, 0, err
+		}
+	}
 	if err := st.UpsertPage(ctx, p); err != nil {
 		return 0, 0, err
+	}
+	if !p.Alive {
+		if _, err := st.RetireSourcePageBlocks(ctx, SourceName, p.ID); err != nil {
+			return 0, 0, err
+		}
+		if _, err := st.RetireSourcePageComments(ctx, SourceName, p.ID); err != nil {
+			return 0, 0, err
+		}
+		return 0, 0, nil
 	}
 	var blocks, comments int
 	if opts.FetchBlocks {
 		blocks, err = c.walkBlocks(ctx, st, p.ID, p.ID, p.SpaceID)
 		if err != nil {
+			return 0, 0, err
+		}
+		if err := st.SetSyncState(ctx, SourceName, "page_blocks", p.ID, "complete"); err != nil {
 			return 0, 0, err
 		}
 	}
@@ -354,6 +371,21 @@ func (c Client) usesDataSourceAPI() bool {
 }
 
 func (c Client) walkBlocks(ctx context.Context, st *store.Store, pageID, parentID, spaceID string) (int, error) {
+	syncedAt, err := st.NextSourceSyncAt(ctx, "block", SourceName)
+	if err != nil {
+		return 0, err
+	}
+	count, err := c.walkBlocksAt(ctx, st, pageID, parentID, spaceID, syncedAt)
+	if err != nil {
+		return count, err
+	}
+	if _, err := st.RetireSourcePageBlocksNotSyncedAt(ctx, SourceName, pageID, syncedAt); err != nil {
+		return count, err
+	}
+	return count, nil
+}
+
+func (c Client) walkBlocksAt(ctx context.Context, st *store.Store, pageID, parentID, spaceID string, syncedAt int64) (int, error) {
 	var count int
 	cursor := ""
 	var displayOrder int64
@@ -392,13 +424,13 @@ func (c Client) walkBlocks(ctx context.Context, st *store.Store, pageID, parentI
 				Alive:          !block.bool("archived") && !block.bool("in_trash"),
 				Source:         SourceName,
 				RawJSON:        raw,
-				SyncedAt:       store.NowMS(),
+				SyncedAt:       syncedAt,
 			}); err != nil {
 				return count, err
 			}
 			count++
 			if shouldFetchBlockChildren(block) {
-				n, err := c.walkBlocks(ctx, st, pageID, block.string("id"), spaceID)
+				n, err := c.walkBlocksAt(ctx, st, pageID, block.string("id"), spaceID, syncedAt)
 				if err != nil {
 					return count, err
 				}

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -310,6 +310,139 @@ func TestSyncWarnsWhenAPIDiscoveryReturnsNothing(t *testing.T) {
 	}
 }
 
+func TestIngestPageMarksBlockSyncOnlyAfterSuccessfulWalk(t *testing.T) {
+	failBlocks := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/blocks/page1/children" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+		if failBlocks {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"object":"error","status":500,"code":"internal_server_error","message":"failed"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"object":"list","results":[],"has_more":false}`))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	page := obj{
+		"id":       "page1",
+		"archived": false,
+		"in_trash": false,
+		"parent":   map[string]any{"type": "workspace", "workspace": true},
+		"properties": map[string]any{
+			"Name": map[string]any{
+				"id": "title", "type": "title",
+				"title": []any{map[string]any{"plain_text": "Page"}},
+			},
+		},
+	}
+	client := Client{BaseURL: server.URL, Version: "2026-03-11", Token: "secret", HTTP: http.DefaultClient}
+	if _, _, err := client.ingestPage(ctx, st, page, ingestPageOptions{FetchBlocks: true}); err != nil {
+		t.Fatal(err)
+	}
+	synced, err := st.HasSyncState(ctx, SourceName, "page_blocks", "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !synced {
+		t.Fatal("successful block walk did not mark page complete")
+	}
+
+	failBlocks = true
+	if _, _, err := client.ingestPage(ctx, st, page, ingestPageOptions{FetchBlocks: true}); err == nil {
+		t.Fatal("expected failed block walk")
+	}
+	synced, err = st.HasSyncState(ctx, SourceName, "page_blocks", "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if synced {
+		t.Fatal("failed block walk retained completion marker")
+	}
+}
+
+func TestIngestArchivedPageRestoresDesktopBlocksWithoutRefetching(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Desktop page", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{ID: "block1", PageID: "page1", ParentID: "page1", Type: "text", Text: "Desktop body", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "API page", Alive: true, Source: SourceName, SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{ID: "block1", PageID: "page1", ParentID: "page1", Type: "paragraph", Text: "API body", Alive: true, Source: SourceName, SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertComment(ctx, store.Comment{ID: "comment1", PageID: "page1", Text: "Desktop comment", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertComment(ctx, store.Comment{ID: "comment1", PageID: "page1", Text: "API comment", Alive: true, Source: SourceName, SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	page := obj{
+		"id":       "page1",
+		"archived": true,
+		"parent":   map[string]any{"type": "workspace", "workspace": true},
+		"properties": map[string]any{
+			"Name": map[string]any{
+				"id":    "title",
+				"type":  "title",
+				"title": []any{map[string]any{"plain_text": "Archived API page"}},
+			},
+		},
+	}
+	if _, _, err := (Client{BaseURL: server.URL, Token: "secret"}).ingestPage(ctx, st, page, ingestPageOptions{FetchBlocks: true, FetchComments: true}); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 0 {
+		t.Fatalf("archived page made %d requests", requests)
+	}
+	pages, err := st.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].Title != "Desktop page" || pages[0].Source != "desktop" {
+		t.Fatalf("restored page = %#v", pages)
+	}
+	blocks, err := st.PageBlocks(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].Text != "Desktop body" || blocks[0].Source != "desktop" {
+		t.Fatalf("restored blocks = %#v", blocks)
+	}
+	comments, err := st.PageComments(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].Text != "Desktop comment" || comments[0].Source != "desktop" {
+		t.Fatalf("Desktop comment was not restored: %#v", comments)
+	}
+}
+
 func TestWalkBlocksSkipsSyncedBlockCopyChildren(t *testing.T) {
 	requestedCopyChildren := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -361,6 +494,64 @@ func TestWalkBlocksSkipsSyncedBlockCopyChildren(t *testing.T) {
 	}
 	if len(blocks) != 1 || blocks[0].ID != "copy1" || blocks[0].Type != "synced_block" {
 		t.Fatalf("unexpected blocks: %+v", blocks)
+	}
+}
+
+func TestWalkBlocksRetiresMissingAPIBlocksAfterSuccessfulWalk(t *testing.T) {
+	includeBlock := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/blocks/page1/children" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+		if !includeBlock {
+			_, _ = w.Write([]byte(`{"object":"list","results":[],"has_more":false}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"object":"list",
+			"results":[{
+				"object":"block",
+				"id":"block1",
+				"type":"paragraph",
+				"has_children":false,
+				"created_time":"2026-01-01T00:00:00Z",
+				"last_edited_time":"2026-01-01T00:00:00Z",
+				"paragraph":{"rich_text":[{"type":"text","plain_text":"remove me","text":{"content":"remove me"}}]}
+			}],
+			"has_more":false
+		}`))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := Client{BaseURL: server.URL, Version: "2026-03-11", Token: "secret", HTTP: http.DefaultClient}
+	if _, err := client.walkBlocks(ctx, st, "page1", "page1", "space1"); err != nil {
+		t.Fatal(err)
+	}
+	blocks, err := st.PageBlocks(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected initial API block, got %#v", blocks)
+	}
+
+	includeBlock = false
+	if _, err := client.walkBlocks(ctx, st, "page1", "page1", "space1"); err != nil {
+		t.Fatal(err)
+	}
+	blocks, err = st.PageBlocks(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 0 {
+		t.Fatalf("missing API block remained live: %#v", blocks)
 	}
 }
 

--- a/internal/notiondesktop/desktop.go
+++ b/internal/notiondesktop/desktop.go
@@ -65,6 +65,7 @@ func Ingest(ctx context.Context, st *store.Store, path, cacheDir string) (Summar
 	}
 	defer db.Close()
 	s := Summary{Source: source}
+	syncedAt := store.NowMS()
 	if err := st.WithTransaction(ctx, func() error {
 		return st.DeferPageFTS(ctx, func() error {
 			if s.Spaces, err = ingestSpaces(ctx, st, db); err != nil {
@@ -79,10 +80,10 @@ func Ingest(ctx context.Context, st *store.Store, path, cacheDir string) (Summar
 			if s.Collections, err = ingestCollections(ctx, st, db); err != nil {
 				return err
 			}
-			if s.Pages, s.Blocks, s.RawRecords, err = ingestBlocks(ctx, st, db); err != nil {
+			if s.Pages, s.Blocks, s.RawRecords, err = ingestBlocks(ctx, st, db, syncedAt); err != nil {
 				return err
 			}
-			if s.Comments, err = ingestComments(ctx, st, db); err != nil {
+			if s.Comments, err = ingestComments(ctx, st, db, syncedAt); err != nil {
 				return err
 			}
 			addedSpaces, err := st.EnsureSpaceFallbacks(ctx, SourceName)
@@ -324,7 +325,7 @@ type localBlock struct {
 	Text           string
 }
 
-func ingestBlocks(ctx context.Context, st *store.Store, db *sql.DB) (pages int, blocks int, rawRecords int, err error) {
+func ingestBlocks(ctx context.Context, st *store.Store, db *sql.DB, syncedAt int64) (pages int, blocks int, rawRecords int, err error) {
 	rows, err := db.QueryContext(ctx, `select id, space_id, type, coalesce(properties, ''), coalesce(content, ''),
 		coalesce(collection_id, ''), coalesce(cast(created_time as integer), 0), coalesce(cast(last_edited_time as integer), 0),
 		coalesce(parent_id, ''), coalesce(parent_table, ''), alive, coalesce(format, ''),
@@ -389,7 +390,7 @@ func ingestBlocks(ctx context.Context, st *store.Store, db *sql.DB) (pages int, 
 				Alive:          b.Alive,
 				Source:         SourceName,
 				RawJSON:        b.RawJSON,
-				SyncedAt:       store.NowMS(),
+				SyncedAt:       syncedAt,
 			}); err != nil {
 				return pages, blocks, rawRecords, err
 			}
@@ -412,14 +413,14 @@ func ingestBlocks(ctx context.Context, st *store.Store, db *sql.DB) (pages int, 
 			Alive:          b.Alive,
 			Source:         SourceName,
 			RawJSON:        b.RawJSON,
-			SyncedAt:       store.NowMS(),
+			SyncedAt:       syncedAt,
 		}); err != nil {
 			return pages, blocks, rawRecords, err
 		}
 		blocks++
 		if err := st.UpsertRawRecord(ctx, store.RawRecord{
 			Source: SourceName, RecordTable: "block", RecordID: b.ID, ParentID: b.ParentID,
-			SpaceID: b.SpaceID, RawJSON: b.RawJSON, SyncedAt: store.NowMS(),
+			SpaceID: b.SpaceID, RawJSON: b.RawJSON, SyncedAt: syncedAt,
 		}); err != nil {
 			return pages, blocks, rawRecords, err
 		}
@@ -495,14 +496,17 @@ func blockText(raw string) string {
 	return notiontext.PlainFromJSON(raw)
 }
 
-func ingestComments(ctx context.Context, st *store.Store, db *sql.DB) (int, error) {
+func ingestComments(ctx context.Context, st *store.Store, db *sql.DB, syncedAt int64) (int, error) {
 	rows, err := db.QueryContext(ctx, `select id, parent_id, space_id, coalesce(text, ''), coalesce(created_by_id, ''),
 		coalesce(cast(created_time as integer), 0), coalesce(cast(last_edited_time as integer), 0), alive,
 		coalesce(json_object('id', id, 'parent_id', parent_id, 'space_id', space_id, 'text', text, 'content', content,
 			'created_by_id', created_by_id, 'created_time', created_time, 'last_edited_time', last_edited_time, 'alive', alive), '{}')
 		from comment`)
 	if err != nil {
-		return 0, ignoreMissingTable(err)
+		if ignoreMissingTable(err) == nil {
+			return 0, nil
+		}
+		return 0, err
 	}
 	defer rows.Close()
 	n := 0
@@ -516,12 +520,14 @@ func ingestComments(ctx context.Context, st *store.Store, db *sql.DB) (int, erro
 		c.Text = notiontext.PlainFromJSON(c.Text)
 		c.Alive = alive != 0
 		c.Source = SourceName
-		c.SyncedAt = store.NowMS()
+		c.SyncedAt = syncedAt
 		if err := st.UpsertComment(ctx, c); err != nil {
 			return n, err
 		}
 		n++
 	}
+	// Desktop's comment table is opportunistic and has no completeness marker.
+	// Only explicit alive=0 rows retire comments; absence is not a tombstone.
 	return n, rows.Err()
 }
 

--- a/internal/notiondesktop/desktop_test.go
+++ b/internal/notiondesktop/desktop_test.go
@@ -96,7 +96,7 @@ func TestIngestBlocksDerivesUntitledPageFromChildText(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer st.Close()
-	if _, _, _, err := ingestBlocks(ctx, st, src); err != nil {
+	if _, _, _, err := ingestBlocks(ctx, st, src, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -106,5 +106,220 @@ func TestIngestBlocksDerivesUntitledPageFromChildText(t *testing.T) {
 	}
 	if title != "Decision log" {
 		t.Fatalf("expected child text title, got %q", title)
+	}
+}
+
+func TestIngestBlocksPreservesRowsMissingFromLatestSnapshot(t *testing.T) {
+	ctx := context.Background()
+	src, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "desktop.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	if _, err := src.ExecContext(ctx, `create table block (
+		id text primary key,
+		space_id text,
+		type text,
+		properties text,
+		content text,
+		collection_id text,
+		created_time integer,
+		last_edited_time integer,
+		parent_id text,
+		parent_table text,
+		alive integer,
+		format text
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.ExecContext(ctx, `insert into block(id, space_id, type, properties, content, collection_id, created_time, last_edited_time, parent_id, parent_table, alive, format)
+		values
+		('page1', 'space1', 'page', '{"title":[["Plan"]]}', '["child1"]', '', 1, 1, '', '', 1, ''),
+		('child1', 'space1', 'text', '{"title":[["Cached body"]]}', '', '', 2, 2, 'page1', 'block', 1, ''),
+		('page2', 'space1', 'page', '{"title":[["Evicted page"]]}', '', '', 3, 3, '', '', 1, ''),
+		('page3', 'space1', 'page', '{"title":[["API page"]]}', '["child3"]', '', 4, 4, '', '', 1, ''),
+		('child3', 'space1', 'text', '{"title":[["API body"]]}', '', '', 5, 5, 'page3', 'block', 1, '')`); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if _, _, _, err := ingestBlocks(ctx, st, src, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Archived API payload", Alive: false, Source: "api", SyncedAt: 9}); err != nil {
+		t.Fatal(err)
+	}
+	var title, source string
+	var alive int
+	if err := st.DB().QueryRowContext(ctx, `select title, source, alive from pages where id = 'page1'`).Scan(&title, &source, &alive); err != nil {
+		t.Fatal(err)
+	}
+	if title != "Plan" || source != "desktop" || alive != 1 {
+		t.Fatalf("dead API payload replaced live Desktop page: title=%q source=%q alive=%d", title, source, alive)
+	}
+	if err := st.UpsertPage(ctx, store.Page{ID: "page3", Title: "API page", Alive: true, Source: "api", SyncedAt: 10}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{ID: "child3", PageID: "page3", ParentID: "page3", Type: "paragraph", Text: "API body", Alive: true, Source: "api", SyncedAt: 10}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := ingestBlocks(ctx, st, src, 2); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.ExecContext(ctx, `delete from block where id in ('child1', 'page2', 'page3', 'child3')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := ingestBlocks(ctx, st, src, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := st.DB().QueryRowContext(ctx, `select alive from blocks where id = 'child1'`).Scan(&alive); err != nil {
+		t.Fatal(err)
+	}
+	if alive != 1 {
+		t.Fatalf("evicted child was retired: %d", alive)
+	}
+	var rawRows int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from raw_records where source = 'desktop' and record_id = 'child1'`).Scan(&rawRows); err != nil {
+		t.Fatal(err)
+	}
+	if rawRows != 1 {
+		t.Fatalf("evicted child raw payload was removed: %d", rawRows)
+	}
+	coverage, err := st.PageBlockCoverage(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if coverage.Referenced != 1 || coverage.Missing != 0 {
+		t.Fatalf("unexpected coverage after eviction: %+v", coverage)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select alive from pages where id = 'page2'`).Scan(&alive); err != nil {
+		t.Fatal(err)
+	}
+	if alive != 1 {
+		t.Fatalf("evicted page was retired: %d", alive)
+	}
+	var ftsRows int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from page_fts where page_id = 'page2'`).Scan(&ftsRows); err != nil {
+		t.Fatal(err)
+	}
+	if ftsRows != 1 {
+		t.Fatalf("evicted page was removed from FTS: %d", ftsRows)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select alive from pages where id = 'page3'`).Scan(&alive); err != nil {
+		t.Fatal(err)
+	}
+	if alive != 1 {
+		t.Fatalf("API-backed page was retired: %d", alive)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select alive from blocks where id = 'child3'`).Scan(&alive); err != nil {
+		t.Fatal(err)
+	}
+	if alive != 1 {
+		t.Fatalf("API-backed block was retired: %d", alive)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select title, source from pages where id = 'page3'`).Scan(&title, &source); err != nil {
+		t.Fatal(err)
+	}
+	if title != "API page" || source != "api" {
+		t.Fatalf("API page payload was overwritten: title=%q source=%q", title, source)
+	}
+	var text string
+	if err := st.DB().QueryRowContext(ctx, `select text, source from blocks where id = 'child3'`).Scan(&text, &source); err != nil {
+		t.Fatal(err)
+	}
+	if text != "API body" || source != "api" {
+		t.Fatalf("API block payload was overwritten: text=%q source=%q", text, source)
+	}
+}
+
+func TestIngestBlocksPreservesPreviousSnapshotWhenCacheQueryIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	src, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "desktop.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	if _, err := src.ExecContext(ctx, `create table block (
+		id text,
+		space_id text,
+		type text,
+		properties text,
+		content text,
+		collection_id text,
+		created_time integer,
+		last_edited_time integer,
+		parent_id text,
+		parent_table text,
+		alive integer,
+		format text
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Keep me", Alive: true, Source: SourceName, SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := ingestBlocks(ctx, st, src, 2); err != nil {
+		t.Fatal(err)
+	}
+	pages, err := st.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].Title != "Keep me" {
+		t.Fatalf("empty cache query retired previous snapshot: %#v", pages)
+	}
+}
+
+func TestIngestCommentsTreatsEmptyCacheAsNonAuthoritative(t *testing.T) {
+	ctx := context.Background()
+	src, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "desktop.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	if _, err := src.ExecContext(ctx, `create table comment (
+		id text,
+		parent_id text,
+		space_id text,
+		text text,
+		content text,
+		created_by_id text,
+		created_time integer,
+		last_edited_time integer,
+		alive integer
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.UpsertComment(ctx, store.Comment{ID: "comment1", PageID: "page1", Text: "Keep me", Alive: true, Source: SourceName, SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	count, err := ingestComments(ctx, st, src, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("empty comment cache reported count=%d", count)
+	}
+	comments, err := st.PageComments(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].Text != "Keep me" {
+		t.Fatalf("empty comment cache altered previous snapshot: %#v", comments)
 	}
 }

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -34,8 +34,9 @@ var exportTables = []string{
 }
 
 type Manifest struct {
-	GeneratedAt string          `json:"generated_at"`
-	Tables      []TableManifest `json:"tables"`
+	GeneratedAt   string          `json:"generated_at"`
+	Tables        []TableManifest `json:"tables"`
+	RecordSources *TableManifest  `json:"record_sources,omitempty"`
 }
 
 type TableManifest struct {
@@ -91,6 +92,12 @@ func Publish(ctx context.Context, st *store.Store, opts PublishOptions) (Publish
 		manifest.Tables = append(manifest.Tables, tm)
 		dataKeep[filepath.Clean(filepath.Join(opts.RepoPath, tm.Path))] = true
 	}
+	recordSources, err := exportTable(ctx, st.DB(), opts.RepoPath, "record_sources")
+	if err != nil {
+		return PublishSummary{}, err
+	}
+	manifest.RecordSources = &recordSources
+	dataKeep[filepath.Clean(filepath.Join(opts.RepoPath, recordSources.Path))] = true
 	if err := pruneGeneratedFiles(dataRoot, dataKeep, func(path string) bool {
 		return strings.HasSuffix(path, ".jsonl.gz")
 	}); err != nil {
@@ -142,15 +149,135 @@ func Import(ctx context.Context, st *store.Store, repoPath string) (Manifest, er
 	if err := json.Unmarshal(b, &manifest); err != nil {
 		return Manifest{}, err
 	}
-	for _, table := range manifest.Tables {
-		if err := importTable(ctx, st.DB(), filepath.Join(repoPath, table.Path), table.Name); err != nil {
+	if err := validateManifest(repoPath, manifest); err != nil {
+		return manifest, err
+	}
+	tx, err := st.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return manifest, err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `delete from record_sources`); err != nil {
+		return manifest, err
+	}
+	for _, table := range exportTables {
+		if _, err := tx.ExecContext(ctx, "delete from "+quoteIdent(table)); err != nil {
 			return manifest, err
 		}
+	}
+	for _, table := range manifest.Tables {
+		rows, err := importTable(ctx, tx, filepath.Join(repoPath, table.Path), table.Name)
+		if err != nil {
+			return manifest, err
+		}
+		if rows != table.Rows {
+			return manifest, fmt.Errorf("snapshot table %s row count mismatch: manifest=%d imported=%d", table.Name, table.Rows, rows)
+		}
+	}
+	if manifest.RecordSources != nil {
+		rows, err := importTable(ctx, tx, filepath.Join(repoPath, manifest.RecordSources.Path), "record_sources")
+		if err != nil {
+			return manifest, err
+		}
+		if rows != manifest.RecordSources.Rows {
+			return manifest, fmt.Errorf("record_sources row count mismatch: manifest=%d imported=%d", manifest.RecordSources.Rows, rows)
+		}
+	} else {
+		if err := rebuildRecordSources(ctx, tx); err != nil {
+			return manifest, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return manifest, err
 	}
 	if err := st.RebuildFTS(ctx); err != nil {
 		return manifest, err
 	}
 	return manifest, nil
+}
+
+func validateManifest(repoPath string, manifest Manifest) error {
+	expected := make(map[string]bool, len(exportTables))
+	for _, table := range exportTables {
+		expected[table] = true
+	}
+	seen := make(map[string]bool, len(manifest.Tables))
+	for _, table := range manifest.Tables {
+		if table.Rows < 0 {
+			return fmt.Errorf("snapshot table %s has negative row count", table.Name)
+		}
+		if !expected[table.Name] {
+			return fmt.Errorf("unsupported snapshot table %q", table.Name)
+		}
+		if seen[table.Name] {
+			return fmt.Errorf("duplicate snapshot table %q", table.Name)
+		}
+		seen[table.Name] = true
+		if err := validateManifestFile(repoPath, table.Path); err != nil {
+			return fmt.Errorf("snapshot table %s: %w", table.Name, err)
+		}
+	}
+	for _, table := range exportTables {
+		if !seen[table] {
+			return fmt.Errorf("snapshot manifest missing required table %q", table)
+		}
+	}
+	if manifest.RecordSources != nil {
+		if manifest.RecordSources.Rows < 0 {
+			return fmt.Errorf("record_sources has negative row count")
+		}
+		if manifest.RecordSources.Name != "record_sources" {
+			return fmt.Errorf("invalid record_sources table name %q", manifest.RecordSources.Name)
+		}
+		if err := validateManifestFile(repoPath, manifest.RecordSources.Path); err != nil {
+			return fmt.Errorf("record_sources snapshot: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateManifestFile(repoPath, path string) error {
+	if path == "" {
+		return fmt.Errorf("missing path")
+	}
+	root, err := filepath.Abs(repoPath)
+	if err != nil {
+		return err
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	full, err := filepath.Abs(filepath.Join(repoPath, path))
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(full)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symlink snapshot path is not allowed: %s", path)
+	}
+	resolved, err := filepath.EvalSymlinks(full)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path escapes snapshot repository: %s", path)
+	}
+	info, err = os.Stat(resolved)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", path)
+	}
+	return nil
 }
 
 func Subscribe(ctx context.Context, st *store.Store, remote, repoPath, branch string) (Manifest, error) {
@@ -221,27 +348,32 @@ func exportTable(ctx context.Context, db *sql.DB, repoPath, table string) (Table
 	return TableManifest{Name: table, Path: path, Rows: count}, nil
 }
 
-func importTable(ctx context.Context, db *sql.DB, path, table string) error {
+type sqlExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func importTable(ctx context.Context, db sqlExecer, path, table string) (int, error) {
 	in, err := os.Open(path)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer in.Close()
 	gz, err := gzip.NewReader(in)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer gz.Close()
 	if _, err := db.ExecContext(ctx, "delete from "+quoteIdent(table)); err != nil {
-		return err
+		return 0, err
 	}
 	scanner := bufio.NewScanner(gz)
 	buf := make([]byte, 0, 1024*1024)
 	scanner.Buffer(buf, 32*1024*1024)
+	count := 0
 	for scanner.Scan() {
 		var row map[string]any
 		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
-			return err
+			return count, err
 		}
 		if len(row) == 0 {
 			continue
@@ -261,10 +393,27 @@ func importTable(ctx context.Context, db *sql.DB, path, table string) error {
 		}
 		stmt := fmt.Sprintf("insert or replace into %s(%s) values(%s)", quoteIdent(table), strings.Join(quotedCols, ","), strings.Join(holders, ","))
 		if _, err := db.ExecContext(ctx, stmt, args...); err != nil {
+			return count, err
+		}
+		count++
+	}
+	return count, scanner.Err()
+}
+
+func rebuildRecordSources(ctx context.Context, db sqlExecer) error {
+	for _, stmt := range []string{
+		`insert into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'page', id, source, synced_at, alive from pages`,
+		`insert into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'block', id, source, synced_at, alive from blocks`,
+		`insert into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'comment', id, source, synced_at, alive from comments`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return err
 		}
 	}
-	return scanner.Err()
+	return nil
 }
 
 func ensureRepo(ctx context.Context, repoPath, remote, branch string) error {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -2,6 +2,7 @@ package share
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,6 +41,14 @@ func TestPublishAndImportSnapshot(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(repo, "pages", "default", "launch-page1.md")); err != nil {
 		t.Fatal(err)
+	}
+	for _, table := range s.Manifest.Tables {
+		if table.Name == "record_sources" {
+			t.Fatal("record_sources must remain outside the legacy tables list")
+		}
+	}
+	if s.Manifest.RecordSources == nil || s.Manifest.RecordSources.Name != "record_sources" {
+		t.Fatal("expected source provenance sidecar")
 	}
 	stalePage := filepath.Join(repo, "pages", "default", "stale.md")
 	if err := os.WriteFile(stalePage, []byte("stale"), 0o644); err != nil {
@@ -84,6 +93,275 @@ func TestPublishAndImportSnapshot(t *testing.T) {
 	}
 	if len(results) != 1 {
 		t.Fatalf("expected imported search result, got %d", len(results))
+	}
+	hasSource, err := dst.RecordHasLiveSource(ctx, "page", "page1", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasSource {
+		t.Fatal("expected imported page source provenance")
+	}
+}
+
+func TestPublishAndImportPreservesMixedSourceProvenance(t *testing.T) {
+	ctx := context.Background()
+	src, err := store.Open(filepath.Join(t.TempDir(), "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	now := store.NowMS()
+	if err := src.UpsertPage(ctx, store.Page{ID: "page1", Title: "Desktop", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := src.UpsertPage(ctx, store.Page{ID: "page1", Title: "API", Alive: true, Source: "api", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := src.UpsertPage(ctx, store.Page{ID: "page1", Title: "Archived", Alive: false, Source: "api", SyncedAt: now + 2}); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo}); err != nil {
+		t.Fatal(err)
+	}
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if _, err := Import(ctx, dst, repo); err != nil {
+		t.Fatal(err)
+	}
+	desktopLive, err := dst.RecordHasLiveSource(ctx, "page", "page1", "desktop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	apiLive, err := dst.RecordHasLiveSource(ctx, "page", "page1", "api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !desktopLive || apiLive {
+		t.Fatalf("source provenance after import: desktop=%v api=%v", desktopLive, apiLive)
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].Title != "Desktop" || pages[0].Source != "desktop" {
+		t.Fatalf("canonical payload after import = %#v", pages)
+	}
+}
+
+func TestImportLegacySnapshotRebuildsSourceProvenance(t *testing.T) {
+	ctx := context.Background()
+	src, mdDir := snapshotStoreForTest(t, ctx, "Launch", "hello")
+	defer src.Close()
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir}); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(repo, "manifest.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest.RecordSources = nil
+	data, err = json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(repo, "data", "record_sources.jsonl.gz")); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if err := dst.UpsertPage(ctx, store.Page{ID: "stale", Title: "Stale destination row", Alive: true, Source: "desktop", SyncedAt: store.NowMS()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, dst, repo); err != nil {
+		t.Fatal(err)
+	}
+	hasSource, err := dst.RecordHasLiveSource(ctx, "page", "page1", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasSource {
+		t.Fatal("expected legacy provenance rebuild")
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].ID != "page1" {
+		t.Fatalf("legacy import retained stale destination rows: %#v", pages)
+	}
+}
+
+func TestImportRejectsIncompleteManifestBeforeClearingDestination(t *testing.T) {
+	ctx := context.Background()
+	src, mdDir := snapshotStoreForTest(t, ctx, "Launch", "hello")
+	defer src.Close()
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir}); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(repo, "manifest.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	var tables []TableManifest
+	for _, table := range manifest.Tables {
+		if table.Name != "pages" {
+			tables = append(tables, table)
+		}
+	}
+	manifest.Tables = tables
+	data, err = json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if err := dst.UpsertPage(ctx, store.Page{ID: "keep", Title: "Keep destination", Alive: true, Source: "desktop", SyncedAt: store.NowMS()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, dst, repo); err == nil {
+		t.Fatal("expected incomplete manifest rejection")
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].ID != "keep" {
+		t.Fatalf("incomplete import altered destination: %#v", pages)
+	}
+}
+
+func TestImportRejectsRowCountMismatchBeforeCommit(t *testing.T) {
+	ctx := context.Background()
+	src, mdDir := snapshotStoreForTest(t, ctx, "Launch", "hello")
+	defer src.Close()
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir}); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(repo, "manifest.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	for i := range manifest.Tables {
+		if manifest.Tables[i].Name == "pages" {
+			manifest.Tables[i].Rows++
+		}
+	}
+	data, err = json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if err := dst.UpsertPage(ctx, store.Page{ID: "keep", Title: "Keep destination", Alive: true, Source: "desktop", SyncedAt: store.NowMS()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, dst, repo); err == nil {
+		t.Fatal("expected row count mismatch rejection")
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].ID != "keep" {
+		t.Fatalf("row count mismatch altered destination: %#v", pages)
+	}
+}
+
+func TestImportRejectsSymlinkedSnapshotFile(t *testing.T) {
+	ctx := context.Background()
+	src, mdDir := snapshotStoreForTest(t, ctx, "Launch", "hello")
+	defer src.Close()
+	repo := t.TempDir()
+	summary, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pagesPath string
+	for _, table := range summary.Manifest.Tables {
+		if table.Name == "pages" {
+			pagesPath = filepath.Join(repo, table.Path)
+			break
+		}
+	}
+	if pagesPath == "" {
+		t.Fatal("pages table missing from manifest")
+	}
+	data, err := os.ReadFile(pagesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "pages.jsonl.gz")
+	if err := os.WriteFile(outside, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(pagesPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, pagesPath); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if err := dst.UpsertPage(ctx, store.Page{ID: "keep", Title: "Keep destination", Alive: true, Source: "desktop", SyncedAt: store.NowMS()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, dst, repo); err == nil {
+		t.Fatal("expected symlinked snapshot rejection")
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].ID != "keep" {
+		t.Fatalf("symlinked import altered destination: %#v", pages)
 	}
 }
 

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -103,6 +103,31 @@ func (s *Store) PageBlocks(ctx context.Context, pageID string) ([]Block, error) 
 	return pageBlocksDisplayOrder(pageID, blocks), nil
 }
 
+func (s *Store) PageBlockCoverage(ctx context.Context, pageID string) (BlockCoverage, error) {
+	var coverage BlockCoverage
+	err := s.queryRowContext(ctx, `with recursive reachable(id) as (
+			select id from blocks
+			where page_id = ? and alive = 1 and (id = ? or parent_id = ?)
+			union
+			select child.id
+			from blocks child
+			join reachable parent on child.parent_id = parent.id
+			where child.page_id = ? and child.alive = 1
+		),
+		referenced as (
+			select distinct parent.id as parent_id, child.value as id
+			from reachable
+			join blocks parent on parent.id = reachable.id
+			join json_each(case when json_valid(parent.content_json) then parent.content_json else '[]' end) child
+			where child.type = 'text' and child.value <> ''
+		)
+		select count(*), coalesce(sum(case when available.id is null then 1 else 0 end), 0)
+		from referenced
+		left join blocks available on available.id = referenced.id and available.parent_id = referenced.parent_id and available.alive = 1`,
+		pageID, pageID, pageID, pageID).Scan(&coverage.Referenced, &coverage.Missing)
+	return coverage, err
+}
+
 func pageBlocksDisplayOrder(pageID string, blocks []Block) []Block {
 	children := map[string][]Block{}
 	for _, block := range blocks {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -13,7 +14,7 @@ import (
 	crawlstore "github.com/openclaw/crawlkit/store"
 )
 
-const schemaVersion = 1
+const schemaVersion = 3
 
 type Store struct {
 	db               *sql.DB
@@ -248,6 +249,16 @@ func (s *Store) init(ctx context.Context) error {
 			primary key (source, record_table, record_id)
 		)`,
 		`create index if not exists raw_records_parent on raw_records(parent_id, record_table)`,
+		`create table if not exists record_sources (
+			record_table text not null,
+			record_id text not null,
+			source text not null,
+			synced_at integer not null,
+			alive integer not null,
+			payload_json text,
+			primary key (record_table, record_id, source)
+		)`,
+		`create index if not exists record_sources_source_sync on record_sources(record_table, source, alive, synced_at)`,
 		`create table if not exists sync_state (
 			source text not null,
 			entity_type text not null,
@@ -280,11 +291,26 @@ func (s *Store) init(ctx context.Context) error {
 	if err := s.ensureColumn(ctx, "collections", "parent_table", "text"); err != nil {
 		return err
 	}
+	if err := s.ensureColumn(ctx, "record_sources", "payload_json", "text"); err != nil {
+		return err
+	}
 	if _, err := s.execContext(ctx, `create index if not exists blocks_page_alive_order on blocks(page_id, alive, parent_id, display_order, created_time, id)`); err != nil {
 		return err
 	}
 	if _, err := s.execContext(ctx, `create index if not exists blocks_page_alive_created on blocks(page_id, alive, created_time, id)`); err != nil {
 		return err
+	}
+	for _, stmt := range []string{
+		`insert or ignore into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'page', id, source, synced_at, alive from pages`,
+		`insert or ignore into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'block', id, source, synced_at, alive from blocks`,
+		`insert or ignore into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'comment', id, source, synced_at, alive from comments`,
+	} {
+		if _, err := s.execContext(ctx, stmt); err != nil {
+			return err
+		}
 	}
 	if _, err := s.execContext(ctx, `insert or replace into meta(key, value) values('schema_version', ?)`, schemaVersion); err != nil {
 		return err
@@ -316,6 +342,25 @@ func (s *Store) ensureColumn(ctx context.Context, table, column, definition stri
 	}
 	_, err = s.execContext(ctx, `alter table `+table+` add column `+column+` `+definition)
 	return err
+}
+
+func (s *Store) RebuildRecordSources(ctx context.Context) error {
+	if _, err := s.execContext(ctx, `delete from record_sources`); err != nil {
+		return err
+	}
+	for _, stmt := range []string{
+		`insert into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'page', id, source, synced_at, alive from pages`,
+		`insert into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'block', id, source, synced_at, alive from blocks`,
+		`insert into record_sources(record_table, record_id, source, synced_at, alive)
+			select 'comment', id, source, synced_at, alive from comments`,
+	} {
+		if _, err := s.execContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func NowMS() int64 {
@@ -406,6 +451,71 @@ func (s *Store) UpsertTeam(ctx context.Context, x Team) error {
 }
 
 func (s *Store) UpsertPage(ctx context.Context, x Page) error {
+	payload, err := json.Marshal(x)
+	if err != nil {
+		return err
+	}
+	canonicalSource, canonicalLive, exists, err := s.canonicalRecordSource(ctx, "page", x.ID)
+	if err != nil {
+		return err
+	}
+	sourcePayload := string(payload)
+	if !x.Alive {
+		sourcePayload = ""
+	}
+	if x.Alive && exists && canonicalSource != x.Source && canonicalLive && !sourcePreferred(x.Source, canonicalSource) {
+		sourcePayload, err = s.preferredFallbackPayload(ctx, "page", x.ID, x.Source, sourcePayload)
+		if err != nil {
+			return err
+		}
+	}
+	if err := s.upsertRecordSource(ctx, "page", x.ID, x.Source, x.SyncedAt, x.Alive, sourcePayload); err != nil {
+		return err
+	}
+	if !exists {
+		if err := s.writeCanonicalPage(ctx, x); err != nil {
+			return err
+		}
+		if err := s.clearRecordSourcePayload(ctx, "page", x.ID, x.Source); err != nil {
+			return err
+		}
+		if err := s.refreshRecordAlive(ctx, "page", x.ID); err != nil {
+			return err
+		}
+		return s.markPageFTS(ctx, x.ID)
+	}
+	if !x.Alive {
+		if canonicalSource == x.Source {
+			if _, err := s.promoteFallbackRecord(ctx, "page", x.ID); err != nil {
+				return err
+			}
+		}
+		if err := s.refreshRecordAlive(ctx, "page", x.ID); err != nil {
+			return err
+		}
+		return s.markPageFTS(ctx, x.ID)
+	}
+	if canonicalSource != x.Source && canonicalLive && !sourcePreferred(x.Source, canonicalSource) {
+		return s.refreshRecordAlive(ctx, "page", x.ID)
+	}
+	if canonicalSource != x.Source && canonicalLive {
+		if err := s.saveCanonicalPayload(ctx, "page", x.ID, canonicalSource); err != nil {
+			return err
+		}
+	}
+	if err := s.writeCanonicalPage(ctx, x); err != nil {
+		return err
+	}
+	if err := s.clearRecordSourcePayload(ctx, "page", x.ID, x.Source); err != nil {
+		return err
+	}
+	if err := s.refreshRecordAlive(ctx, "page", x.ID); err != nil {
+		return err
+	}
+	return s.markPageFTS(ctx, x.ID)
+}
+
+func (s *Store) writeCanonicalPage(ctx context.Context, x Page) error {
 	_, err := s.execContext(ctx, `insert into pages(
 		id, space_id, parent_id, parent_table, collection_id, title, url, icon, cover, properties_json,
 		created_time, last_edited_time, alive, source, raw_json, synced_at)
@@ -428,13 +538,93 @@ func (s *Store) UpsertPage(ctx context.Context, x Page) error {
 			synced_at=excluded.synced_at`,
 		x.ID, x.SpaceID, x.ParentID, x.ParentTable, x.CollectionID, x.Title, x.URL, x.Icon, x.Cover, x.PropertiesJSON,
 		x.CreatedTime, x.LastEditedTime, BoolInt(x.Alive), x.Source, x.RawJSON, x.SyncedAt)
-	if err != nil {
-		return err
-	}
-	return s.markPageFTS(ctx, x.ID)
+	return err
 }
 
 func (s *Store) UpsertBlock(ctx context.Context, x Block) error {
+	payload, err := json.Marshal(x)
+	if err != nil {
+		return err
+	}
+	canonicalSource, canonicalLive, exists, err := s.canonicalRecordSource(ctx, "block", x.ID)
+	if err != nil {
+		return err
+	}
+	sourcePayload := string(payload)
+	if !x.Alive {
+		sourcePayload = ""
+	}
+	if x.Alive && exists && canonicalSource != x.Source && canonicalLive && !sourcePreferred(x.Source, canonicalSource) {
+		sourcePayload, err = s.preferredFallbackPayload(ctx, "block", x.ID, x.Source, sourcePayload)
+		if err != nil {
+			return err
+		}
+	}
+	if err := s.upsertRecordSource(ctx, "block", x.ID, x.Source, x.SyncedAt, x.Alive, sourcePayload); err != nil {
+		return err
+	}
+	if !exists {
+		if err := s.writeCanonicalBlock(ctx, x); err != nil {
+			return err
+		}
+		if err := s.clearRecordSourcePayload(ctx, "block", x.ID, x.Source); err != nil {
+			return err
+		}
+		if err := s.refreshRecordAlive(ctx, "block", x.ID); err != nil {
+			return err
+		}
+		if x.PageID != "" {
+			return s.markPageFTS(ctx, x.PageID)
+		}
+		return nil
+	}
+	if !x.Alive {
+		if canonicalSource == x.Source {
+			if _, err := s.promoteFallbackRecord(ctx, "block", x.ID); err != nil {
+				return err
+			}
+		}
+		if err := s.refreshRecordAlive(ctx, "block", x.ID); err != nil {
+			return err
+		}
+		if x.PageID != "" {
+			return s.markPageFTS(ctx, x.PageID)
+		}
+		return nil
+	}
+	if canonicalSource != x.Source && canonicalLive && !sourcePreferred(x.Source, canonicalSource) {
+		return s.refreshRecordAlive(ctx, "block", x.ID)
+	}
+	if canonicalSource != x.Source && canonicalLive {
+		if err := s.saveCanonicalPayload(ctx, "block", x.ID, canonicalSource); err != nil {
+			return err
+		}
+	}
+	current, err := s.blockByID(ctx, x.ID)
+	if err != nil {
+		return err
+	}
+	if err := s.writeCanonicalBlock(ctx, x); err != nil {
+		return err
+	}
+	if err := s.clearRecordSourcePayload(ctx, "block", x.ID, x.Source); err != nil {
+		return err
+	}
+	if err := s.refreshRecordAlive(ctx, "block", x.ID); err != nil {
+		return err
+	}
+	if current.PageID != "" && current.PageID != x.PageID {
+		if err := s.markPageFTS(ctx, current.PageID); err != nil {
+			return err
+		}
+	}
+	if x.PageID != "" {
+		return s.markPageFTS(ctx, x.PageID)
+	}
+	return nil
+}
+
+func (s *Store) writeCanonicalBlock(ctx context.Context, x Block) error {
 	_, err := s.execContext(ctx, `insert into blocks(
 		id, page_id, space_id, parent_id, parent_table, type, text, properties_json, content_json, format_json,
 		display_order, created_time, last_edited_time, alive, source, raw_json, synced_at)
@@ -458,13 +648,513 @@ func (s *Store) UpsertBlock(ctx context.Context, x Block) error {
 			synced_at=excluded.synced_at`,
 		x.ID, x.PageID, x.SpaceID, x.ParentID, x.ParentTable, x.Type, x.Text, x.PropertiesJSON, x.ContentJSON, x.FormatJSON,
 		x.DisplayOrder, x.CreatedTime, x.LastEditedTime, BoolInt(x.Alive), x.Source, x.RawJSON, x.SyncedAt)
+	return err
+}
+
+func (s *Store) RetireSourcePageBlocks(ctx context.Context, source, pageID string) (int, error) {
+	rows, err := s.queryContext(ctx, `select record_sources.record_id
+		from record_sources
+		join blocks on blocks.id = record_sources.record_id
+		where record_sources.record_table = 'block'
+			and record_sources.source = ?
+			and record_sources.alive = 1
+			and (
+				(coalesce(record_sources.payload_json, '') <> ''
+					and json_valid(record_sources.payload_json)
+					and json_extract(record_sources.payload_json, '$.PageID') = ?)
+				or
+				(coalesce(record_sources.payload_json, '') = ''
+					and blocks.source = record_sources.source
+					and blocks.page_id = ?)
+			)`, source, pageID, pageID)
+	if err != nil {
+		return 0, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	for _, id := range ids {
+		if _, err := s.execContext(ctx, `update record_sources set alive = 0, payload_json = null
+			where record_table = 'block' and record_id = ? and source = ?`, id, source); err != nil {
+			return 0, err
+		}
+		canonicalSource, _, exists, err := s.canonicalRecordSource(ctx, "block", id)
+		if err != nil {
+			return 0, err
+		}
+		if exists && canonicalSource == source {
+			if _, err := s.promoteFallbackRecord(ctx, "block", id); err != nil {
+				return 0, err
+			}
+		}
+		if err := s.refreshRecordAlive(ctx, "block", id); err != nil {
+			return 0, err
+		}
+	}
+	if err := s.markPageFTS(ctx, pageID); err != nil {
+		return 0, err
+	}
+	return len(ids), nil
+}
+
+func (s *Store) RetireSourcePageBlocksNotSyncedAt(ctx context.Context, source, pageID string, syncedAt int64) (int, error) {
+	rows, err := s.queryContext(ctx, `select record_sources.record_id
+		from record_sources
+		join blocks on blocks.id = record_sources.record_id
+		where record_sources.record_table = 'block'
+			and record_sources.source = ?
+			and record_sources.alive = 1
+			and record_sources.synced_at <> ?
+			and (
+				(coalesce(record_sources.payload_json, '') <> ''
+					and json_valid(record_sources.payload_json)
+					and json_extract(record_sources.payload_json, '$.PageID') = ?)
+				or
+				(coalesce(record_sources.payload_json, '') = ''
+					and blocks.source = record_sources.source
+					and blocks.page_id = ?)
+			)`, source, syncedAt, pageID, pageID)
+	if err != nil {
+		return 0, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	for _, id := range ids {
+		if err := s.retireRecordSource(ctx, "block", id, source); err != nil {
+			return 0, err
+		}
+	}
+	if err := s.markPageFTS(ctx, pageID); err != nil {
+		return 0, err
+	}
+	return len(ids), nil
+}
+
+func (s *Store) RetireSourcePageComments(ctx context.Context, source, pageID string) (int64, error) {
+	ids, err := s.sourceCommentIDsForPage(ctx, source, pageID)
+	if err != nil {
+		return 0, err
+	}
+	for _, id := range ids {
+		if err := s.retireRecordSource(ctx, "comment", id, source); err != nil {
+			return 0, err
+		}
+	}
+	return int64(len(ids)), nil
+}
+
+func (s *Store) sourceCommentIDsForPage(ctx context.Context, source, pageID string) ([]string, error) {
+	rows, err := s.queryContext(ctx, `select record_sources.record_id
+		from record_sources
+		join comments on comments.id = record_sources.record_id
+		where record_sources.record_table = 'comment'
+			and record_sources.source = ?
+			and record_sources.alive = 1
+			and (
+				(coalesce(record_sources.payload_json, '') <> ''
+					and json_valid(record_sources.payload_json)
+					and json_extract(record_sources.payload_json, '$.PageID') = ?)
+				or
+				(coalesce(record_sources.payload_json, '') = ''
+					and comments.source = record_sources.source
+					and comments.page_id = ?)
+			)`, source, pageID, pageID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (s *Store) retireRecordSource(ctx context.Context, recordTable, recordID, source string) error {
+	if _, err := s.execContext(ctx, `update record_sources set alive = 0, payload_json = null
+		where record_table = ? and record_id = ? and source = ?`, recordTable, recordID, source); err != nil {
+		return err
+	}
+	canonicalSource, _, exists, err := s.canonicalRecordSource(ctx, recordTable, recordID)
 	if err != nil {
 		return err
 	}
-	if x.PageID != "" {
-		return s.markPageFTS(ctx, x.PageID)
+	if exists && canonicalSource == source {
+		if _, err := s.promoteFallbackRecord(ctx, recordTable, recordID); err != nil {
+			return err
+		}
+	}
+	if err := s.refreshRecordAlive(ctx, recordTable, recordID); err != nil {
+		return err
+	}
+	if recordTable == "comment" {
+		return s.refreshCommentFTS(ctx, recordID)
 	}
 	return nil
+}
+
+func (s *Store) upsertRecordSource(ctx context.Context, recordTable, recordID, source string, syncedAt int64, alive bool, payload string) error {
+	_, err := s.execContext(ctx, `insert into record_sources(record_table, record_id, source, synced_at, alive, payload_json)
+		values (?, ?, ?, ?, ?, nullif(?, ''))
+		on conflict(record_table, record_id, source) do update set
+			synced_at = excluded.synced_at,
+			alive = excluded.alive,
+			payload_json = excluded.payload_json`,
+		recordTable, recordID, source, syncedAt, BoolInt(alive), payload)
+	return err
+}
+
+func sourcePreferred(incoming, current string) bool {
+	if incoming == "api" {
+		return current != "api"
+	}
+	return current != "api"
+}
+
+func (s *Store) preferredFallbackPayload(ctx context.Context, recordTable, recordID, source, incoming string) (string, error) {
+	var existing sql.NullString
+	err := s.queryRowContext(ctx, `select payload_json from record_sources
+		where record_table = ? and record_id = ? and source = ?`, recordTable, recordID, source).Scan(&existing)
+	if errors.Is(err, sql.ErrNoRows) || !existing.Valid || existing.String == "" {
+		return incoming, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	incoming = preserveFallbackStructure(recordTable, existing.String, incoming)
+	if fallbackPayloadPreferred(recordTable, existing.String, incoming) {
+		return incoming, nil
+	}
+	return existing.String, nil
+}
+
+func preserveFallbackStructure(recordTable, existing, incoming string) string {
+	if recordTable != "block" {
+		return incoming
+	}
+	var oldValue, newValue Block
+	if json.Unmarshal([]byte(existing), &oldValue) != nil || json.Unmarshal([]byte(incoming), &newValue) != nil {
+		return incoming
+	}
+	if newValue.PageID != "" || oldValue.PageID == "" {
+		return incoming
+	}
+	newValue.PageID = oldValue.PageID
+	if newValue.SpaceID == "" {
+		newValue.SpaceID = oldValue.SpaceID
+	}
+	if newValue.ParentID == "" {
+		newValue.ParentID = oldValue.ParentID
+	}
+	if newValue.ParentTable == "" {
+		newValue.ParentTable = oldValue.ParentTable
+	}
+	if newValue.Type == "" {
+		newValue.Type = oldValue.Type
+	}
+	if newValue.Text == "" {
+		newValue.Text = oldValue.Text
+	}
+	if newValue.PropertiesJSON == "" {
+		newValue.PropertiesJSON = oldValue.PropertiesJSON
+	}
+	if newValue.ContentJSON == "" {
+		newValue.ContentJSON = oldValue.ContentJSON
+	}
+	if newValue.FormatJSON == "" {
+		newValue.FormatJSON = oldValue.FormatJSON
+	}
+	if newValue.RawJSON == "" {
+		newValue.RawJSON = oldValue.RawJSON
+	}
+	payload, err := json.Marshal(newValue)
+	if err != nil {
+		return incoming
+	}
+	return string(payload)
+}
+
+func fallbackPayloadPreferred(recordTable, existing, incoming string) bool {
+	switch recordTable {
+	case "page":
+		var oldValue, newValue Page
+		if json.Unmarshal([]byte(existing), &oldValue) != nil || json.Unmarshal([]byte(incoming), &newValue) != nil {
+			return false
+		}
+		if newValue.LastEditedTime != oldValue.LastEditedTime {
+			return newValue.LastEditedTime > oldValue.LastEditedTime
+		}
+		return pagePayloadQuality(newValue) >= pagePayloadQuality(oldValue)
+	case "block":
+		var oldValue, newValue Block
+		if json.Unmarshal([]byte(existing), &oldValue) != nil || json.Unmarshal([]byte(incoming), &newValue) != nil {
+			return false
+		}
+		if newValue.LastEditedTime != oldValue.LastEditedTime {
+			return newValue.LastEditedTime > oldValue.LastEditedTime
+		}
+		return blockPayloadQuality(newValue) >= blockPayloadQuality(oldValue)
+	case "comment":
+		var oldValue, newValue Comment
+		if json.Unmarshal([]byte(existing), &oldValue) != nil || json.Unmarshal([]byte(incoming), &newValue) != nil {
+			return false
+		}
+		if newValue.LastEditedTime != oldValue.LastEditedTime {
+			return newValue.LastEditedTime > oldValue.LastEditedTime
+		}
+		return len(newValue.Text)+len(newValue.RawJSON) >= len(oldValue.Text)+len(oldValue.RawJSON)
+	default:
+		return false
+	}
+}
+
+func pagePayloadQuality(x Page) int {
+	return len(x.Title) + len(x.URL) + len(x.Icon) + len(x.Cover) + len(x.PropertiesJSON) + len(x.RawJSON)
+}
+
+func blockPayloadQuality(x Block) int {
+	return len(x.Text) + len(x.PropertiesJSON) + len(x.ContentJSON) + len(x.FormatJSON) + len(x.RawJSON)
+}
+
+func (s *Store) canonicalRecordSource(ctx context.Context, recordTable, recordID string) (string, bool, bool, error) {
+	table, err := canonicalTable(recordTable)
+	if err != nil {
+		return "", false, false, err
+	}
+	var source string
+	var live int
+	err = s.queryRowContext(ctx, `select source, exists(
+			select 1 from record_sources
+			where record_table = ? and record_id = ? and source = `+table+`.source and alive = 1
+		)
+		from `+table+` where id = ?`, recordTable, recordID, recordID).Scan(&source, &live)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, false, nil
+	}
+	return source, IntBool(live), err == nil, err
+}
+
+func canonicalTable(recordTable string) (string, error) {
+	switch recordTable {
+	case "page":
+		return "pages", nil
+	case "block":
+		return "blocks", nil
+	case "comment":
+		return "comments", nil
+	default:
+		return "", fmt.Errorf("unsupported record table %q", recordTable)
+	}
+}
+
+func (s *Store) clearRecordSourcePayload(ctx context.Context, recordTable, recordID, source string) error {
+	_, err := s.execContext(ctx, `update record_sources set payload_json = null
+		where record_table = ? and record_id = ? and source = ?`, recordTable, recordID, source)
+	return err
+}
+
+func (s *Store) saveCanonicalPayload(ctx context.Context, recordTable, recordID, source string) error {
+	var payload []byte
+	switch recordTable {
+	case "page":
+		x, err := s.pageByID(ctx, recordID)
+		if err != nil {
+			return err
+		}
+		payload, err = json.Marshal(x)
+		if err != nil {
+			return err
+		}
+	case "block":
+		x, err := s.blockByID(ctx, recordID)
+		if err != nil {
+			return err
+		}
+		payload, err = json.Marshal(x)
+		if err != nil {
+			return err
+		}
+	case "comment":
+		x, err := s.commentByID(ctx, recordID)
+		if err != nil {
+			return err
+		}
+		payload, err = json.Marshal(x)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported record table %q", recordTable)
+	}
+	_, err := s.execContext(ctx, `update record_sources set payload_json = ?
+		where record_table = ? and record_id = ? and source = ?`, string(payload), recordTable, recordID, source)
+	return err
+}
+
+func (s *Store) promoteFallbackRecord(ctx context.Context, recordTable, recordID string) (bool, error) {
+	var source, payload string
+	err := s.queryRowContext(ctx, `select source, payload_json
+		from record_sources
+		where record_table = ? and record_id = ? and alive = 1 and coalesce(payload_json, '') <> ''
+		order by case when source = 'api' then 0 else 1 end, synced_at desc
+		limit 1`, recordTable, recordID).Scan(&source, &payload)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	switch recordTable {
+	case "page":
+		var x Page
+		if err := json.Unmarshal([]byte(payload), &x); err != nil {
+			return false, err
+		}
+		x.Source = source
+		x.Alive = true
+		if err := s.writeCanonicalPage(ctx, x); err != nil {
+			return false, err
+		}
+		if err := s.markPageFTS(ctx, x.ID); err != nil {
+			return false, err
+		}
+	case "block":
+		var x Block
+		if err := json.Unmarshal([]byte(payload), &x); err != nil {
+			return false, err
+		}
+		current, err := s.blockByID(ctx, recordID)
+		if err != nil {
+			return false, err
+		}
+		x.Source = source
+		x.Alive = true
+		if err := s.writeCanonicalBlock(ctx, x); err != nil {
+			return false, err
+		}
+		if current.PageID != "" && current.PageID != x.PageID {
+			if err := s.markPageFTS(ctx, current.PageID); err != nil {
+				return false, err
+			}
+		}
+		if x.PageID != "" {
+			if err := s.markPageFTS(ctx, x.PageID); err != nil {
+				return false, err
+			}
+		}
+	case "comment":
+		var x Comment
+		if err := json.Unmarshal([]byte(payload), &x); err != nil {
+			return false, err
+		}
+		x.Source = source
+		x.Alive = true
+		if err := s.writeCanonicalComment(ctx, x); err != nil {
+			return false, err
+		}
+		if err := s.refreshCommentFTS(ctx, x.ID); err != nil {
+			return false, err
+		}
+	default:
+		return false, fmt.Errorf("unsupported record table %q", recordTable)
+	}
+	if err := s.clearRecordSourcePayload(ctx, recordTable, recordID, source); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Store) pageByID(ctx context.Context, id string) (Page, error) {
+	var x Page
+	var alive int
+	err := s.queryRowContext(ctx, `select id, space_id, parent_id, parent_table, collection_id, title, url, icon, cover,
+		properties_json, created_time, last_edited_time, alive, source, raw_json, synced_at
+		from pages where id = ?`, id).Scan(
+		&x.ID, &x.SpaceID, &x.ParentID, &x.ParentTable, &x.CollectionID, &x.Title, &x.URL, &x.Icon, &x.Cover,
+		&x.PropertiesJSON, &x.CreatedTime, &x.LastEditedTime, &alive, &x.Source, &x.RawJSON, &x.SyncedAt)
+	x.Alive = IntBool(alive)
+	return x, err
+}
+
+func (s *Store) blockByID(ctx context.Context, id string) (Block, error) {
+	var x Block
+	var alive int
+	err := s.queryRowContext(ctx, `select id, page_id, space_id, parent_id, parent_table, type, text, properties_json,
+		content_json, format_json, display_order, created_time, last_edited_time, alive, source, raw_json, synced_at
+		from blocks where id = ?`, id).Scan(
+		&x.ID, &x.PageID, &x.SpaceID, &x.ParentID, &x.ParentTable, &x.Type, &x.Text, &x.PropertiesJSON,
+		&x.ContentJSON, &x.FormatJSON, &x.DisplayOrder, &x.CreatedTime, &x.LastEditedTime, &alive, &x.Source, &x.RawJSON, &x.SyncedAt)
+	x.Alive = IntBool(alive)
+	return x, err
+}
+
+func (s *Store) commentByID(ctx context.Context, id string) (Comment, error) {
+	var x Comment
+	var alive int
+	err := s.queryRowContext(ctx, `select id, page_id, space_id, parent_id, text, created_by_id,
+		created_time, last_edited_time, alive, raw_json, source, synced_at
+		from comments where id = ?`, id).Scan(
+		&x.ID, &x.PageID, &x.SpaceID, &x.ParentID, &x.Text, &x.CreatedByID,
+		&x.CreatedTime, &x.LastEditedTime, &alive, &x.RawJSON, &x.Source, &x.SyncedAt)
+	x.Alive = IntBool(alive)
+	return x, err
+}
+
+func (s *Store) RecordHasLiveSource(ctx context.Context, recordTable, recordID, source string) (bool, error) {
+	var exists int
+	err := s.queryRowContext(ctx, `select exists(
+		select 1 from record_sources
+		where record_table = ? and record_id = ? and source = ? and alive = 1
+	)`, recordTable, recordID, source).Scan(&exists)
+	return exists != 0, err
+}
+
+func (s *Store) refreshRecordAlive(ctx context.Context, recordTable, recordID string) error {
+	table := ""
+	switch recordTable {
+	case "page":
+		table = "pages"
+	case "block":
+		table = "blocks"
+	case "comment":
+		table = "comments"
+	default:
+		return fmt.Errorf("unsupported record table %q", recordTable)
+	}
+	_, err := s.execContext(ctx, `update `+table+` set alive = exists (
+		select 1 from record_sources
+		where record_table = ? and record_id = ? and alive = 1
+	) where id = ?`, recordTable, recordID, recordID)
+	return err
 }
 
 func (s *Store) UpsertCollection(ctx context.Context, x Collection) error {
@@ -478,6 +1168,71 @@ func (s *Store) UpsertCollection(ctx context.Context, x Collection) error {
 }
 
 func (s *Store) UpsertComment(ctx context.Context, x Comment) error {
+	payload, err := json.Marshal(x)
+	if err != nil {
+		return err
+	}
+	canonicalSource, canonicalLive, exists, err := s.canonicalRecordSource(ctx, "comment", x.ID)
+	if err != nil {
+		return err
+	}
+	sourcePayload := string(payload)
+	if !x.Alive {
+		sourcePayload = ""
+	}
+	if x.Alive && exists && canonicalSource != x.Source && canonicalLive && !sourcePreferred(x.Source, canonicalSource) {
+		sourcePayload, err = s.preferredFallbackPayload(ctx, "comment", x.ID, x.Source, sourcePayload)
+		if err != nil {
+			return err
+		}
+	}
+	if err := s.upsertRecordSource(ctx, "comment", x.ID, x.Source, x.SyncedAt, x.Alive, sourcePayload); err != nil {
+		return err
+	}
+	if !exists {
+		if err := s.writeCanonicalComment(ctx, x); err != nil {
+			return err
+		}
+		if err := s.clearRecordSourcePayload(ctx, "comment", x.ID, x.Source); err != nil {
+			return err
+		}
+		if err := s.refreshRecordAlive(ctx, "comment", x.ID); err != nil {
+			return err
+		}
+		return s.refreshCommentFTS(ctx, x.ID)
+	}
+	if !x.Alive {
+		if canonicalSource == x.Source {
+			if _, err := s.promoteFallbackRecord(ctx, "comment", x.ID); err != nil {
+				return err
+			}
+		}
+		if err := s.refreshRecordAlive(ctx, "comment", x.ID); err != nil {
+			return err
+		}
+		return s.refreshCommentFTS(ctx, x.ID)
+	}
+	if canonicalSource != x.Source && canonicalLive && !sourcePreferred(x.Source, canonicalSource) {
+		return s.refreshRecordAlive(ctx, "comment", x.ID)
+	}
+	if canonicalSource != x.Source && canonicalLive {
+		if err := s.saveCanonicalPayload(ctx, "comment", x.ID, canonicalSource); err != nil {
+			return err
+		}
+	}
+	if err := s.writeCanonicalComment(ctx, x); err != nil {
+		return err
+	}
+	if err := s.clearRecordSourcePayload(ctx, "comment", x.ID, x.Source); err != nil {
+		return err
+	}
+	if err := s.refreshRecordAlive(ctx, "comment", x.ID); err != nil {
+		return err
+	}
+	return s.refreshCommentFTS(ctx, x.ID)
+}
+
+func (s *Store) writeCanonicalComment(ctx context.Context, x Comment) error {
 	_, err := s.execContext(ctx, `insert into comments(id, page_id, space_id, parent_id, text, created_by_id, created_time, last_edited_time, alive, raw_json, source, synced_at)
 		values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		on conflict(id) do update set page_id=excluded.page_id, space_id=excluded.space_id, parent_id=excluded.parent_id,
@@ -485,14 +1240,22 @@ func (s *Store) UpsertComment(ctx context.Context, x Comment) error {
 			last_edited_time=excluded.last_edited_time, alive=excluded.alive, raw_json=excluded.raw_json,
 			source=excluded.source, synced_at=excluded.synced_at`,
 		x.ID, x.PageID, x.SpaceID, x.ParentID, x.Text, x.CreatedByID, x.CreatedTime, x.LastEditedTime, BoolInt(x.Alive), x.RawJSON, x.Source, x.SyncedAt)
+	return err
+}
+
+func (s *Store) refreshCommentFTS(ctx context.Context, commentID string) error {
+	if _, err := s.execContext(ctx, `delete from comment_fts where comment_id = ?`, commentID); err != nil {
+		return err
+	}
+	var pageID, text string
+	err := s.queryRowContext(ctx, `select page_id, text from comments where id = ? and alive = 1`, commentID).Scan(&pageID, &text)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
-	_, err = s.execContext(ctx, `delete from comment_fts where comment_id = ?`, x.ID)
-	if err != nil {
-		return err
-	}
-	_, err = s.execContext(ctx, `insert into comment_fts(comment_id, page_id, body) values (?, ?, ?)`, x.ID, x.PageID, x.Text)
+	_, err = s.execContext(ctx, `insert into comment_fts(comment_id, page_id, body) values (?, ?, ?)`, commentID, pageID, text)
 	return err
 }
 
@@ -511,6 +1274,34 @@ func (s *Store) SetSyncState(ctx context.Context, source, entityType, entityID, 
 		on conflict(source, entity_type, entity_id) do update set cursor=excluded.cursor, synced_at=excluded.synced_at`,
 		source, entityType, entityID, cursor, NowMS())
 	return err
+}
+
+func (s *Store) ClearSyncState(ctx context.Context, source, entityType, entityID string) error {
+	_, err := s.execContext(ctx, `delete from sync_state
+		where source = ? and entity_type = ? and entity_id = ?`, source, entityType, entityID)
+	return err
+}
+
+func (s *Store) HasSyncState(ctx context.Context, source, entityType, entityID string) (bool, error) {
+	var exists int
+	err := s.queryRowContext(ctx, `select exists(
+		select 1 from sync_state
+		where source = ? and entity_type = ? and entity_id = ?
+	)`, source, entityType, entityID).Scan(&exists)
+	return exists != 0, err
+}
+
+func (s *Store) NextSourceSyncAt(ctx context.Context, recordTable, source string) (int64, error) {
+	var latest sql.NullInt64
+	if err := s.queryRowContext(ctx, `select max(synced_at) from record_sources
+		where record_table = ? and source = ?`, recordTable, source).Scan(&latest); err != nil {
+		return 0, err
+	}
+	now := NowMS()
+	if latest.Valid && latest.Int64 >= now {
+		return latest.Int64 + 1, nil
+	}
+	return now, nil
 }
 
 func (s *Store) DeferPageFTS(ctx context.Context, fn func() error) error {
@@ -552,8 +1343,11 @@ func (s *Store) markPageFTS(ctx context.Context, pageID string) error {
 }
 
 func (s *Store) refreshPageFTS(ctx context.Context, pageID string) error {
+	if _, err := s.execContext(ctx, `delete from page_fts where page_id = ?`, pageID); err != nil {
+		return err
+	}
 	var title string
-	if err := s.queryRowContext(ctx, `select title from pages where id = ?`, pageID).Scan(&title); err != nil {
+	if err := s.queryRowContext(ctx, `select title from pages where id = ? and alive = 1`, pageID).Scan(&title); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		}
@@ -564,9 +1358,6 @@ func (s *Store) refreshPageFTS(ctx context.Context, pageID string) error {
 		return err
 	}
 	parts := pageBlockTextParts(pageID, blocks)
-	if _, err := s.execContext(ctx, `delete from page_fts where page_id = ?`, pageID); err != nil {
-		return err
-	}
 	_, err = s.execContext(ctx, `insert into page_fts(page_id, title, body) values (?, ?, ?)`, pageID, title, strings.Join(parts, "\n"))
 	return err
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -34,6 +34,194 @@ func TestStoreUpsertsAndSearchesPage(t *testing.T) {
 	}
 }
 
+func TestStoreRestoresDesktopPayloadWhenAPISourceRetires(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := NowMS()
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Desktop title", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{ID: "block1", PageID: "page1", ParentID: "page1", Type: "text", Text: "Desktop body", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "API title", Alive: true, Source: "api", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{ID: "block1", PageID: "page1", ParentID: "page1", Type: "paragraph", Text: "API body", Alive: true, Source: "api", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Archived API title", Alive: false, Source: "api", SyncedAt: now + 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{ID: "block1", PageID: "page1", ParentID: "page1", Type: "paragraph", Text: "Archived API body", Alive: false, Source: "api", SyncedAt: now + 2}); err != nil {
+		t.Fatal(err)
+	}
+
+	pages, err := st.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].Title != "Desktop title" || pages[0].Source != "desktop" {
+		t.Fatalf("restored page = %#v", pages)
+	}
+	blocks, err := st.PageBlocks(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].Text != "Desktop body" || blocks[0].Source != "desktop" {
+		t.Fatalf("restored blocks = %#v", blocks)
+	}
+}
+
+func TestStoreKeepsStructureWhenNewerFallbackPayloadIsOrphaned(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := NowMS()
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "page1", ParentID: "page1", Type: "text", Text: "Complete Desktop body",
+		ContentJSON: `["child1","child2"]`, LastEditedTime: 10, Alive: true, Source: "desktop", SyncedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "page1", ParentID: "page1", Type: "paragraph", Text: "API body",
+		LastEditedTime: 10, Alive: true, Source: "api", SyncedAt: now + 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", Type: "text",
+		LastEditedTime: 11, Alive: true, Source: "desktop", SyncedAt: now + 2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "page1", ParentID: "page1", Type: "paragraph", Text: "Archived API body",
+		LastEditedTime: 12, Alive: false, Source: "api", SyncedAt: now + 3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	blocks, err := st.PageBlocks(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 || blocks[0].Text != "Complete Desktop body" || blocks[0].ContentJSON != `["child1","child2"]` {
+		t.Fatalf("fallback payload was degraded: %#v", blocks)
+	}
+}
+
+func TestStoreRefreshesBothPageIndexesWhenFallbackBlockMoved(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := NowMS()
+	if err := st.UpsertPage(ctx, Page{ID: "desktop-page", Title: "Desktop page", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, Page{ID: "api-page", Title: "API page", Alive: true, Source: "api", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "desktop-page", ParentID: "desktop-page", Type: "text", Text: "desktop destination",
+		Alive: true, Source: "desktop", SyncedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "api-page", ParentID: "api-page", Type: "paragraph", Text: "api destination",
+		Alive: true, Source: "api", SyncedAt: now + 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "api-page", ParentID: "api-page", Type: "paragraph", Text: "archived api destination",
+		Alive: false, Source: "api", SyncedAt: now + 2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	results, err := st.Search(ctx, "destination", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].ID != "desktop-page" {
+		t.Fatalf("moved fallback remained indexed under old page: %#v", results)
+	}
+}
+
+func TestStoreRefreshesBothPageIndexesWhenLiveBlockMoves(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := NowMS()
+	for _, page := range []Page{
+		{ID: "old-page", Title: "Old page", Alive: true, Source: "api", SyncedAt: now},
+		{ID: "new-page", Title: "New page", Alive: true, Source: "api", SyncedAt: now},
+	} {
+		if err := st.UpsertPage(ctx, page); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "old-page", ParentID: "old-page", Type: "paragraph", Text: "moving target",
+		Alive: true, Source: "api", SyncedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{
+		ID: "block1", PageID: "new-page", ParentID: "new-page", Type: "paragraph", Text: "moving target",
+		Alive: true, Source: "api", SyncedAt: now + 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	results, err := st.Search(ctx, "moving", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].ID != "new-page" {
+		t.Fatalf("live move remained indexed under old page: %#v", results)
+	}
+}
+
+func TestStoreRestoresCommentPayload(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := NowMS()
+	if err := st.UpsertComment(ctx, Comment{ID: "comment1", PageID: "page1", Text: "Desktop comment", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertComment(ctx, Comment{ID: "comment1", PageID: "page1", Text: "API comment", Alive: true, Source: "api", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertComment(ctx, Comment{ID: "comment1", PageID: "page1", Text: "Archived API comment", Alive: false, Source: "api", SyncedAt: now + 2}); err != nil {
+		t.Fatal(err)
+	}
+	comments, err := st.PageComments(ctx, "page1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].Text != "Desktop comment" || comments[0].Source != "desktop" {
+		t.Fatalf("restored comments = %#v", comments)
+	}
+}
+
 func TestStoreSearchRanksByRelevanceThenRecency(t *testing.T) {
 	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
 	if err != nil {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -67,6 +67,11 @@ type Block struct {
 	SyncedAt       int64
 }
 
+type BlockCoverage struct {
+	Referenced int
+	Missing    int
+}
+
 type Collection struct {
 	ID          string
 	SpaceID     string

--- a/internal/tableexport/export.go
+++ b/internal/tableexport/export.go
@@ -36,7 +36,7 @@ type exportColumn struct {
 	Header string
 }
 
-type referenceLabels struct {
+type ReferenceLabels struct {
 	Users map[string]string
 	Pages map[string]string
 }
@@ -100,16 +100,16 @@ func (e Exporter) Export(ctx context.Context, databaseID string, format Format, 
 	return Summary{Database: collection.ID, Rows: len(pages), Columns: len(columns)}, nil
 }
 
-func (e Exporter) referenceLabels(ctx context.Context) (referenceLabels, error) {
+func (e Exporter) referenceLabels(ctx context.Context) (ReferenceLabels, error) {
 	users, err := e.Store.UserNames(ctx)
 	if err != nil {
-		return referenceLabels{}, err
+		return ReferenceLabels{}, err
 	}
 	pages, err := e.Store.PageTitles(ctx)
 	if err != nil {
-		return referenceLabels{}, err
+		return ReferenceLabels{}, err
 	}
-	return referenceLabels{Users: users, Pages: pages}, nil
+	return ReferenceLabels{Users: users, Pages: pages}, nil
 }
 
 func columnsFor(collection store.Collection, pages []store.Page) []exportColumn {
@@ -198,7 +198,7 @@ func decodeMap(raw string) map[string]any {
 	return out
 }
 
-func propertyValueText(v any, refs referenceLabels) string {
+func propertyValueText(v any, refs ReferenceLabels) string {
 	if text, ok := desktopValueText(v, refs); ok {
 		return text
 	}
@@ -245,7 +245,11 @@ func propertyValueText(v any, refs referenceLabels) string {
 	return notiontext.Plain(v)
 }
 
-func desktopValueText(v any, refs referenceLabels) (string, bool) {
+func PropertyText(v any, refs ReferenceLabels) string {
+	return propertyValueText(v, refs)
+}
+
+func desktopValueText(v any, refs ReferenceLabels) (string, bool) {
 	text, ok := desktopPlain(v, refs)
 	if !ok {
 		return "", false
@@ -254,7 +258,7 @@ func desktopValueText(v any, refs referenceLabels) (string, bool) {
 	return text, true
 }
 
-func desktopPlain(v any, refs referenceLabels) (string, bool) {
+func desktopPlain(v any, refs ReferenceLabels) (string, bool) {
 	switch x := v.(type) {
 	case nil:
 		return "", true
@@ -296,7 +300,7 @@ func desktopPlain(v any, refs referenceLabels) (string, bool) {
 	}
 }
 
-func desktopRefListText(v any, refs referenceLabels) string {
+func desktopRefListText(v any, refs ReferenceLabels) string {
 	items, ok := v.([]any)
 	if !ok {
 		return notiontext.Plain(v)
@@ -310,7 +314,7 @@ func desktopRefListText(v any, refs referenceLabels) string {
 	return strings.Join(parts, " ")
 }
 
-func desktopRefText(v any, refs referenceLabels) string {
+func desktopRefText(v any, refs ReferenceLabels) string {
 	item, ok := v.([]any)
 	if !ok || len(item) == 0 {
 		return notiontext.Plain(v)
@@ -381,7 +385,7 @@ func joinNamed(v any) string {
 	return strings.Join(parts, ", ")
 }
 
-func joinIDs(v any, refs referenceLabels) string {
+func joinIDs(v any, refs ReferenceLabels) string {
 	items, ok := v.([]any)
 	if !ok {
 		return ""
@@ -418,7 +422,7 @@ func dateText(v any) string {
 	return start
 }
 
-func formulaText(v any, refs referenceLabels) string {
+func formulaText(v any, refs ReferenceLabels) string {
 	m, ok := v.(map[string]any)
 	if !ok {
 		return ""
@@ -443,7 +447,7 @@ func formulaText(v any, refs referenceLabels) string {
 	return notiontext.Plain(v)
 }
 
-func rollupText(v any, refs referenceLabels) string {
+func rollupText(v any, refs ReferenceLabels) string {
 	m, ok := v.(map[string]any)
 	if !ok {
 		return ""


### PR DESCRIPTION
## Summary

- make Markdown export retain recursively fetched page blocks instead of producing title-only files
- improve API, desktop, share-link, table, and store traversal coverage for complete Notion archives
- add regression coverage for pagination, nested content, collections, and missing block data
- raise the development version to 0.5.0

## Verification

- `go test ./...`
- `go vet ./...`
- `govulncheck ./...` (no vulnerabilities in called code)
- `goreleaser release --snapshot --clean`
- structured Codex autoreview: clean, no accepted/actionable findings

## Redacted runtime proof

No page titles, page content, tokens, or private identifiers are included below.

- Real Notion Desktop cache -> fresh temporary database: crawled 3,199 pages and 11,141 blocks; 3,149 pages, 10,709 blocks, and 432 comments remained live after tombstones were applied.
- Markdown export wrote 3,149 files. It reported 2,859 incomplete cache snapshots and 152,324 missing block references; exactly 2,859 files contained the explicit incomplete-cache warning instead of silently appearing title-only.
- Existing archive upgrade: a real archive copy was converted to the v0.4 schema shape (`schema_version=1`, no `record_sources`). Opening it with this branch migrated it to schema 3 without changing 3,182 pages, 11,124 blocks, or 432 comments. The migration backfilled 14,738 provenance rows, exactly matching the combined record count.
- Fresh-create behavior: a new database initialized at schema 3 with zero records and exported successfully.
- Legacy share compatibility: the current-main/v0.4 binary published a nine-table manifest without `record_sources`; this branch subscribed to it and preserved all 3,182 pages, 11,124 blocks, and 432 comments while rebuilding all 14,738 provenance rows.
- New share round trip: this branch published a `record_sources` sidecar with 14,738 rows, subscribed from a fresh database, and preserved the page/block/comment and provenance counts.
- API behavior: no live API token was present, so API sync was verified against the deterministic Notion HTTP fixtures in `internal/notionapi`. Current data-source ingestion, successful-walk sync marking, and stale API-block retirement all passed.

The `CHANGELOG.md` entry is intentional: this is the explicitly requested 0.5.0 version change and the archive behavior is user-facing.
