### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,13 @@ jobs:
         run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
 
       - name: Deadcode
-        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
+        run: |
+          output_file=$(mktemp)
+          "$(go env GOPATH)/bin/deadcode" -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Install deadcode
+        run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
+
+      - name: Deadcode
+        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -433,10 +433,6 @@ func ensureRepo(ctx context.Context, repoPath, remote, branch string) error {
 	return nil
 }
 
-func hasChanges(ctx context.Context, repoPath string) (bool, error) {
-	return mirror.Dirty(ctx, mirror.Options{RepoPath: repoPath})
-}
-
 func pullForUpdate(ctx context.Context, repoPath, remote, branch string) error {
 	if strings.TrimSpace(remote) != "" {
 		return mirror.Pull(ctx, mirror.Options{RepoPath: repoPath, Remote: remote, Branch: branch})

--- a/internal/store/query.go
+++ b/internal/store/query.go
@@ -311,24 +311,6 @@ func (s *Store) SpaceName(ctx context.Context, id string) (string, error) {
 	return fallbackSpaceName(id), nil
 }
 
-func (s *Store) TeamName(ctx context.Context, id string) (string, error) {
-	if id == "" {
-		return "", nil
-	}
-	var name sql.NullString
-	err := s.queryRowContext(ctx, `select name from teams where id = ?`, id).Scan(&name)
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return "team-" + shortID(id), nil
-		}
-		return "", err
-	}
-	if name.Valid && name.String != "" {
-		return name.String, nil
-	}
-	return "team-" + shortID(id), nil
-}
-
 func (s *Store) PageTeamID(ctx context.Context, page Page) (string, error) {
 	seen := map[string]bool{page.ID: true}
 	return s.resolveTeamID(ctx, page.ParentTable, page.ParentID, page.CollectionID, seen)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -344,25 +344,6 @@ func (s *Store) ensureColumn(ctx context.Context, table, column, definition stri
 	return err
 }
 
-func (s *Store) RebuildRecordSources(ctx context.Context) error {
-	if _, err := s.execContext(ctx, `delete from record_sources`); err != nil {
-		return err
-	}
-	for _, stmt := range []string{
-		`insert into record_sources(record_table, record_id, source, synced_at, alive)
-			select 'page', id, source, synced_at, alive from pages`,
-		`insert into record_sources(record_table, record_id, source, synced_at, alive)
-			select 'block', id, source, synced_at, alive from blocks`,
-		`insert into record_sources(record_table, record_id, source, synced_at, alive)
-			select 'comment', id, source, synced_at, alive from comments`,
-	} {
-		if _, err := s.execContext(ctx, stmt); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func NowMS() int64 {
 	return time.Now().UnixMilli()
 }


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable helpers reported by deadcode\n- make the workflow fail when deadcode emits findings

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go test -count=1 ./...`
- `go build ./cmd/notcrawl`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
