### PR TITLE
fix: Windows support (directory pruning, default desktop path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,25 @@ jobs:
           ./bin/notcrawl --config "$cfg" --db "$db" status --json | grep -q '"databases"'
           ./bin/notcrawl --config "$cfg" --db "$db" tui --json --limit 1 | grep -q '^\['
 
+  windows-test:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test
+        run: go test -count=1 ./...
+
+      - name: Build CLI
+        run: go build -ldflags "-X main.version=ci" -o notcrawl.exe ./cmd/notcrawl
+
   release-check:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update `crawlkit` to v0.11.0.
 - API sync now tolerates Notion `restricted_resource` failures from `/users`, continues page/database discovery without user labels, and warns when API discovery returns no pages, databases, blocks, or comments. Thanks @elijahmuraoka.
 - API sync now skips fetching copied synced-block children that Notion reports as `object_not_found`, while still storing the synced-block copy. Thanks @elijahmuraoka.
+- Support Notion Desktop defaults and stale-directory pruning on Windows. Thanks @MrJngomonkey.
 
 ## 0.4.0 - 2026-05-18
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 
 const (
 	defaultDirName        = ".notcrawl"
-	defaultDesktopPath    = "~/Library/Application Support/Notion/notion.db"
 	defaultAPIVersion     = "2026-03-11"
 	defaultMCPBaseURL     = "https://chatgpt.com/backend-api/wham/apps"
 	defaultMCPAuthPath    = "~/.codex/auth.json"
@@ -159,9 +159,30 @@ func WriteStarter(path string) (string, error) {
 	return path, crawlconfig.WriteTOML(path, cfg, 0o600)
 }
 
+// defaultDesktopPath returns the Notion Desktop cache location for the
+// current platform: Electron userData is ~/Library/Application Support on
+// macOS, %APPDATA% on Windows, and $XDG_CONFIG_HOME (default ~/.config) on
+// Linux.
+func defaultDesktopPath() string {
+	switch runtime.GOOS {
+	case "windows":
+		if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" && filepath.IsAbs(appData) {
+			return filepath.Join(appData, "Notion", "notion.db")
+		}
+		return "~/AppData/Roaming/Notion/notion.db"
+	case "darwin":
+		return "~/Library/Application Support/Notion/notion.db"
+	default:
+		if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" && filepath.IsAbs(xdg) {
+			return filepath.Join(xdg, "Notion", "notion.db")
+		}
+		return "~/.config/Notion/notion.db"
+	}
+}
+
 func (c *Config) Resolve() error {
 	if strings.TrimSpace(c.Notion.Desktop.Path) == "" {
-		c.Notion.Desktop.Path = defaultDesktopPath
+		c.Notion.Desktop.Path = defaultDesktopPath()
 	}
 	if strings.TrimSpace(c.Notion.API.TokenEnv) == "" {
 		c.Notion.API.TokenEnv = "NOTION_TOKEN"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -25,5 +27,45 @@ func TestDefaultConfiguresExperimentalNotionMCPSource(t *testing.T) {
 	}
 	if !filepath.IsAbs(cfg.Notion.MCP.AuthPath) {
 		t.Fatalf("auth path was not expanded: %q", cfg.Notion.MCP.AuthPath)
+	}
+}
+
+func TestDefaultDesktopPathUsesPlatformCacheLocation(t *testing.T) {
+	appData := filepath.Join(string(filepath.Separator), "appdata")
+	if runtime.GOOS == "windows" {
+		appData = `C:\appdata`
+	}
+	t.Setenv("APPDATA", appData)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(string(filepath.Separator), "xdg"))
+
+	var want string
+	switch runtime.GOOS {
+	case "windows":
+		want = filepath.Join(os.Getenv("APPDATA"), "Notion", "notion.db")
+	case "darwin":
+		want = "~/Library/Application Support/Notion/notion.db"
+	default:
+		want = filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "Notion", "notion.db")
+	}
+	if got := defaultDesktopPath(); got != want {
+		t.Fatalf("default desktop path = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultDesktopPathFallsBackWhenPlatformEnvironmentIsMissing(t *testing.T) {
+	t.Setenv("APPDATA", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	var want string
+	switch runtime.GOOS {
+	case "windows":
+		want = "~/AppData/Roaming/Notion/notion.db"
+	case "darwin":
+		want = "~/Library/Application Support/Notion/notion.db"
+	default:
+		want = "~/.config/Notion/notion.db"
+	}
+	if got := defaultDesktopPath(); got != want {
+		t.Fatalf("fallback desktop path = %q, want %q", got, want)
 	}
 }

--- a/internal/markdown/export.go
+++ b/internal/markdown/export.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/openclaw/notcrawl/internal/notiontext"
@@ -563,7 +562,10 @@ func pruneStaleMarkdown(root string, keep map[string]bool) error {
 }
 
 func isIgnorableRemoveDirError(err error) bool {
-	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST)
+	// os.ErrExist matches EEXIST/ENOTEMPTY on Unix and ERROR_DIR_NOT_EMPTY on
+	// Windows; syscall.ENOTEMPTY is an invented constant on Windows and never
+	// matches the real error.
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrExist)
 }
 
 func formatMS(ms int64) string {

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/openclaw/crawlkit/mirror"
@@ -571,7 +570,7 @@ func pruneGeneratedFiles(root string, keep map[string]bool, shouldPrune func(str
 		return len(dirs[i]) > len(dirs[j])
 	})
 	for _, dir := range dirs {
-		if err := os.Remove(dir); err != nil && !os.IsNotExist(err) && !errors.Is(err, syscall.ENOTEMPTY) && !errors.Is(err, syscall.EEXIST) {
+		if err := os.Remove(dir); err != nil && !os.IsNotExist(err) && !errors.Is(err, os.ErrExist) {
 			return err
 		}
 	}

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -481,6 +481,7 @@ func snapshotStoreForTest(t *testing.T, ctx context.Context, title, text string)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = st.Close() })
 	now := store.NowMS()
 	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: title, Alive: true, Source: "test", SyncedAt: now}); err != nil {
 		t.Fatal(err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -678,7 +679,9 @@ func TestStoreOpenAppliesSQLitePragmasAndPrivateFileMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm()&0o077 != 0 {
+	// Unix permission bits are fabricated on Windows (writable files always
+	// stat as 0666); privacy there comes from inherited NTFS ACLs instead.
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
 		t.Fatalf("database should not be group/world-readable: %s", info.Mode().Perm())
 	}
 


### PR DESCRIPTION
## Summary

Upstream only releases linux/darwin builds, but `go build` on Windows works — except two real product bugs made the tool unusable there. This PR fixes both, plus two Windows-only test issues. **27 tests failed on Windows before these changes; `go test ./...` is fully green after.**

### 1. `export-md` and `publish` failed on every run (directory pruning)

`isIgnorableRemoveDirError` (internal/markdown/export.go) and the duplicated prune predicate in `pruneGeneratedFiles` (internal/share/share.go) ignored `syscall.ENOTEMPTY` / `syscall.EEXIST` after `os.Remove` on a possibly-non-empty directory.

On Windows, `syscall.ENOTEMPTY` is an invented constant (`APPLICATION_ERROR+90`) that never matches a real OS error, and `os.Remove` on a non-empty directory returns `ERROR_DIR_NOT_EMPTY` — so the "directory still has files, that is fine" case was treated as a hard error and every `export-md` / `publish` run failed.

The predicate now checks `errors.Is(err, os.ErrNotExist) || errors.Is(err, os.ErrExist)`:
- **Windows:** `ERROR_DIR_NOT_EMPTY` maps to `os.ErrExist`.
- **Unix: behavior is unchanged** — the stdlib maps `os.ErrExist` to exactly `EEXIST || ENOTEMPTY` (`syscall_unix.go`), the same two errnos the old code listed.

### 2. `sync --source desktop` silently ingested 0 pages (default desktop path)

`defaultDesktopPath` was a hardcoded macOS path (`~/Library/Application Support/Notion/notion.db`). On Windows that expanded to a location under the user profile that Notion Desktop never writes, so desktop sync quietly found nothing. It is now resolved per GOOS (Electron userData dir):

- **windows:** `%APPDATA%\Notion\notion.db`
- **darwin:** unchanged
- **linux:** `$XDG_CONFIG_HOME/Notion/notion.db`, falling back to `~/.config/Notion/notion.db`

### Test fixes

- `internal/store`: the perm-bits assertion (`0o077`) is skipped on Windows — Go fabricates `0666` for writable files there; privacy comes from inherited NTFS ACLs.
- `internal/share`: `snapshotStoreForTest` now closes the store via `t.Cleanup`, so an early `t.Fatal` does not leave the SQLite file locked and break `TempDir` cleanup on Windows.

## Testing

- Windows 11, Go 1.26.4: `go build ./...`, `go vet ./...`, `go test ./...` all green (27 test failures before this PR).
- Unix behavior is unchanged by construction (see the `os.ErrExist` ↔ `EEXIST||ENOTEMPTY` mapping equivalence above); existing tests cover both prune sites.

## Possible follow-up

With these fixes the binary is fully functional on Windows. If you are open to it, adding `windows` to the `goos` list in `.goreleaser.yml` (with a zip `format_overrides` for the archive) would let Windows users get release builds — happy to send that as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)