### PR TITLE
fix(api): retry Cloudflare 524 timeouts

### DIFF
--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -614,7 +614,8 @@ func shouldRetry(err notionAPIError) bool {
 	}
 	return err.StatusCode == http.StatusBadGateway ||
 		err.StatusCode == http.StatusServiceUnavailable ||
-		err.StatusCode == http.StatusGatewayTimeout
+		err.StatusCode == http.StatusGatewayTimeout ||
+		err.StatusCode == 524 // Cloudflare timeout, returned by Notion for transient upstream stalls.
 }
 
 func retryAfter(header string, body []byte) time.Duration {

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -668,3 +668,40 @@ func TestIngestCommentsRetriesTransientGatewayError(t *testing.T) {
 		t.Fatalf("unexpected comments: %+v", comments)
 	}
 }
+
+func TestIngestCommentsRetriesCloudflareTimeout(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if r.URL.Path != "/comments" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+		attempts++
+		if attempts == 1 {
+			w.WriteHeader(524)
+			_, _ = w.Write([]byte(`<!DOCTYPE html><title>Notion</title>`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"object":"list",
+			"results":[],
+			"has_more":false
+		}`))
+	}))
+	defer server.Close()
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	count, err := (Client{BaseURL: server.URL, Version: "2026-03-11", Token: "secret", HTTP: http.DefaultClient}).ingestComments(context.Background(), st, "page1", "space1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 || attempts != 2 {
+		t.Fatalf("unexpected count/attempts: count=%d attempts=%d", count, attempts)
+	}
+}


### PR DESCRIPTION
## Summary
- Treat Cloudflare 524 responses from Notion as retryable API failures.
- Add coverage for a transient 524 HTML response followed by a successful comments response.

## Why
Notion can return an HTML Cloudflare 524 timeout for otherwise transient upstream stalls. This is equivalent in practice to the existing 502/503/504 retry handling, and without retry the sync can fail on a temporary Notion edge timeout.

## Test
- `go test ./...`
