### PR TITLE
ci: update maintenance tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -41,7 +41,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
 
       - name: Run govulncheck
         run: '"$(go env GOPATH)/bin/govulncheck" ./...'
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -71,7 +71,7 @@ jobs:
         run: go vet ./...
 
       - name: Install deadcode
-        run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
+        run: go install golang.org/x/tools/cmd/deadcode@v0.46.0
 
       - name: Deadcode
         run: |
@@ -87,7 +87,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -141,7 +141,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -152,7 +152,7 @@ jobs:
           cache: true
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@v7.2.1
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag_name || github.ref }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@v3.95.5
+        uses: trufflesecurity/trufflehog@v3.95.6
         with:
           path: ./
           base: ${{ steps.scan_range.outputs.base }}


### PR DESCRIPTION
## Summary

- update workflow checkouts to `actions/checkout@v7`
- update `govulncheck` to v1.4.0 and `deadcode` to x/tools v0.46.0
- update the snapshot GoReleaser action to v7.2.2
- update TruffleHog to v3.95.6

The checkout action retains the Node 24 runtime already used by v6. The scanner and action updates are stable releases with error-propagation, resolution, verification, and long-line scanning fixes.

Upstream:

- https://github.com/actions/checkout/releases/tag/v7.0.0
- https://github.com/golang/vuln/releases/tag/v1.4.0
- https://github.com/goreleaser/goreleaser-action/releases/tag/v7.2.2
- https://github.com/trufflesecurity/trufflehog/releases/tag/v3.95.6

## Verification

- `actionlint`
- current `deadcode -test ./...`
- current `govulncheck ./...`: no vulnerabilities
- `goreleaser check`
- `go mod verify`; clean `gofmt`; `go vet ./...`; `go test -count=1 ./...`
- native CLI build and Windows amd64 cross-build
- built CLI doctor/status JSON shape, no-match search, and desktop sync smoke
- Codex autoreview: clean

The desktop smoke found no local cached pages and emitted counts only; no private Notion content was exposed. This is CI-only maintenance, with no release or application behavior change.
