### PR TITLE
fix: retry atomic snapshot pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.5.1 - Unreleased
 
+- Retry concurrent Git snapshot branch-and-tag pushes after rebasing and retargeting the unpublished tag.
 - Retry transient Cloudflare 524 timeouts from Notion API requests. Thanks @davelutztx.
 - Update `golang.org/x/sys` to v0.46.0, resolving a Windows integer-overflow advisory in the dependency graph.
 - Add immutable Git share snapshot tags and non-mutating historical imports with `update --ref`.

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619110145-3f71740424ec
+	github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	modernc.org/libc v1.73.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619110145-3f71740424ec h1:GGKfFqeOtJZj5g3jlmA1Xv0MAkXKbqHKbFjs06vMfCo=
-github.com/openclaw/crawlkit v0.12.3-0.20260619110145-3f71740424ec/go.mod h1:GwfF/ZPPIaAy1lKcWIhA/YgcOXPHA+8rJm5Ned+AuIc=
+github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78 h1:7ebiHhILVHAJT+b4h2CVu/xeUKsLN3nNSfq994uo/3I=
+github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=
 github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -80,6 +80,11 @@ func Publish(ctx context.Context, st *store.Store, opts PublishOptions) (Publish
 	if err := mirror.ValidateTag(ctx, mirror.Options{RepoPath: opts.RepoPath, Remote: opts.Remote, Branch: opts.Branch}, opts.Tag); err != nil {
 		return PublishSummary{}, err
 	}
+	if opts.Push {
+		if err := mirror.SyncForWrite(ctx, mirror.Options{RepoPath: opts.RepoPath, Remote: opts.Remote, Branch: opts.Branch, DirMode: 0o750}); err != nil {
+			return PublishSummary{}, err
+		}
+	}
 	dataRoot := filepath.Join(opts.RepoPath, "data")
 	pagesRoot := filepath.Join(opts.RepoPath, "pages")
 	if err := os.MkdirAll(dataRoot, 0o755); err != nil {
@@ -159,7 +164,7 @@ func Publish(ctx context.Context, st *store.Store, opts PublishOptions) (Publish
 		if strings.TrimSpace(opts.Tag) == "" {
 			err = mirror.Push(ctx, mirrorOpts)
 		} else {
-			err = mirror.PushAtomic(ctx, mirrorOpts, "HEAD:refs/heads/"+opts.Branch, "refs/tags/"+opts.Tag)
+			err = mirror.PushSnapshot(ctx, mirrorOpts, opts.Tag)
 		}
 		if err != nil {
 			return s, err
@@ -538,7 +543,7 @@ func rebuildRecordSources(ctx context.Context, db sqlExecer) error {
 }
 
 func ensureRepo(ctx context.Context, repoPath, remote, branch string) error {
-	opts := mirror.Options{RepoPath: repoPath, Remote: remote, Branch: branch}
+	opts := mirror.Options{RepoPath: repoPath, Remote: remote, Branch: branch, DirMode: 0o750}
 	if strings.TrimSpace(remote) != "" {
 		return mirror.EnsureRemote(ctx, opts)
 	}

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -385,6 +385,31 @@ func TestEnsureRepoUpdatesExistingOrigin(t *testing.T) {
 	}
 }
 
+func TestPublishWithoutPushDoesNotFetchRemote(t *testing.T) {
+	ctx := context.Background()
+	repo := filepath.Join(t.TempDir(), "repo")
+	runGitForTest(t, t.TempDir(), "init", "-b", "main", repo)
+	st, mdDir := snapshotStoreForTest(t, ctx, "Local", "offline snapshot")
+	_, err := Publish(ctx, st, PublishOptions{
+		RepoPath:    repo,
+		Remote:      "https://example.invalid/archive.git",
+		Branch:      "main",
+		MarkdownDir: mdDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Publish(ctx, st, PublishOptions{
+		RepoPath:    repo,
+		Remote:      "https://example.invalid/archive.git",
+		Branch:      "main",
+		MarkdownDir: mdDir,
+		Commit:      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPublishTagRequiresCommitBeforeWriting(t *testing.T) {
 	repo := filepath.Join(t.TempDir(), "repo")
 	if _, err := Publish(context.Background(), nil, PublishOptions{RepoPath: repo, Tag: "snapshot/test"}); err == nil {
@@ -392,6 +417,25 @@ func TestPublishTagRequiresCommitBeforeWriting(t *testing.T) {
 	}
 	if _, err := os.Stat(repo); !os.IsNotExist(err) {
 		t.Fatalf("failed tagged publish should not create repo: %v", err)
+	}
+}
+
+func TestPublishValidatesTagBeforeRemoteSync(t *testing.T) {
+	ctx := context.Background()
+	repo := filepath.Join(t.TempDir(), "repo")
+	runGitForTest(t, t.TempDir(), "init", "-b", "main", repo)
+	st, mdDir := snapshotStoreForTest(t, ctx, "Local", "offline snapshot")
+	_, err := Publish(ctx, st, PublishOptions{
+		RepoPath:    repo,
+		Remote:      "https://example.invalid/archive.git",
+		Branch:      "main",
+		MarkdownDir: mdDir,
+		Commit:      true,
+		Push:        true,
+		Tag:         "bad tag",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid snapshot tag") {
+		t.Fatalf("Publish error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- retry concurrent atomic snapshot branch-and-tag pushes through CrawlKit
- preserve unrelated share-repository edits during retry rebases
- keep no-push publishes offline and validate tags before remote synchronization
- cover no-commit, commit-only, and invalid-tag preflight behavior

## Proof

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- autoreview clean
