### PR TITLE
fix(api): retry transient transport errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.3 - Unreleased
 
+- Retry transient transport failures during read-only Notion API requests. Thanks @davelutztx.
+
 ## 0.5.2 - 2026-07-09
 
 - Sign official macOS release binaries with the OpenClaw Foundation Developer ID while keeping local and cross-platform builds credential-free.

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -542,7 +542,7 @@ func (c Client) do(ctx context.Context, method, path string, body any, out any) 
 		}
 		resp, err := c.HTTP.Do(req)
 		if err != nil {
-			if attempt < maxAPIAttempts && shouldRetryTransportError(ctx, err) {
+			if attempt < maxAPIAttempts && shouldRetryTransportError(ctx, method, path, err) {
 				if err := waitBeforeRetry(ctx, 0); err != nil {
 					return err
 				}
@@ -625,11 +625,28 @@ func shouldRetry(err notionAPIError) bool {
 		err.StatusCode == 524 // Cloudflare timeout, returned by Notion for transient upstream stalls.
 }
 
-func shouldRetryTransportError(ctx context.Context, err error) bool {
+func shouldRetryTransportError(ctx context.Context, method, path string, err error) bool {
 	if err == nil || ctx.Err() != nil {
 		return false
 	}
-	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+	return isReplaySafeRequest(method, path) &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded)
+}
+
+func isReplaySafeRequest(method, path string) bool {
+	if method == http.MethodGet || method == http.MethodHead {
+		return true
+	}
+	if method != http.MethodPost {
+		return false
+	}
+	path, _, _ = strings.Cut(path, "?")
+	if path == "/search" {
+		return true
+	}
+	return (strings.HasPrefix(path, "/databases/") || strings.HasPrefix(path, "/data_sources/")) &&
+		strings.HasSuffix(path, "/query")
 }
 
 func retryAfter(header string, body []byte) time.Duration {

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -541,6 +542,12 @@ func (c Client) do(ctx context.Context, method, path string, body any, out any) 
 		}
 		resp, err := c.HTTP.Do(req)
 		if err != nil {
+			if attempt < maxAPIAttempts && shouldRetryTransportError(ctx, err) {
+				if err := waitBeforeRetry(ctx, 0); err != nil {
+					return err
+				}
+				continue
+			}
 			return err
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
@@ -616,6 +623,13 @@ func shouldRetry(err notionAPIError) bool {
 		err.StatusCode == http.StatusServiceUnavailable ||
 		err.StatusCode == http.StatusGatewayTimeout ||
 		err.StatusCode == 524 // Cloudflare timeout, returned by Notion for transient upstream stalls.
+}
+
+func shouldRetryTransportError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
 func retryAfter(header string, body []byte) time.Duration {

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -551,8 +551,18 @@ func (c Client) do(ctx context.Context, method, path string, body any, out any) 
 			return err
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-			defer resp.Body.Close()
-			return json.NewDecoder(resp.Body).Decode(out)
+			responseBody, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				if attempt < maxAPIAttempts && shouldRetryTransportError(ctx, method, path, readErr) {
+					if err := waitBeforeRetry(ctx, 0); err != nil {
+						return err
+					}
+					continue
+				}
+				return readErr
+			}
+			return json.Unmarshal(responseBody, out)
 		}
 
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -629,6 +629,22 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type errorAfterDataReadCloser struct {
+	data []byte
+	err  error
+}
+
+func (r *errorAfterDataReadCloser) Read(p []byte) (int, error) {
+	if len(r.data) > 0 {
+		n := copy(p, r.data)
+		r.data = r.data[n:]
+		return n, nil
+	}
+	return 0, r.err
+}
+
+func (r *errorAfterDataReadCloser) Close() error { return nil }
+
 func TestDoRetriesTransportError(t *testing.T) {
 	attempts := 0
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -640,6 +656,38 @@ func TestDoRetriesTransportError(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Header:     make(http.Header),
 			Body:       io.NopCloser(strings.NewReader(`{"object":"list","results":[],"has_more":false}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	var out map[string]any
+	err := (Client{BaseURL: "https://api.notion.com/v1", Version: "2022-06-28", Token: "secret", HTTP: client}).do(context.Background(), http.MethodGet, "/users", nil, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	if out["object"] != "list" {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+}
+
+func TestDoRetriesTransportErrorWhileReadingResponse(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		body := io.ReadCloser(io.NopCloser(strings.NewReader(`{"object":"list","results":[],"has_more":false}`)))
+		if attempts == 1 {
+			body = &errorAfterDataReadCloser{
+				data: []byte(`{"object":"list","results":`),
+				err:  errors.New("read: connection reset by peer"),
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       body,
 			Request:    req,
 		}, nil
 	})}

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -3,9 +3,12 @@ package notionapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/openclaw/notcrawl/internal/store"
@@ -617,6 +620,40 @@ func TestWalkBlocksFetchesOriginalSyncedBlockChildren(t *testing.T) {
 	}
 	if len(blocks) != 2 || blocks[0].ID != "source1" || blocks[1].ID != "child1" {
 		t.Fatalf("unexpected blocks: %+v", blocks)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDoRetriesTransportError(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, errors.New("read: connection reset by peer")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"object":"list","results":[],"has_more":false}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	var out map[string]any
+	err := (Client{BaseURL: "https://api.notion.com/v1", Version: "2022-06-28", Token: "secret", HTTP: client}).do(context.Background(), http.MethodGet, "/users", nil, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	if out["object"] != "list" {
+		t.Fatalf("unexpected response: %+v", out)
 	}
 }
 

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -657,6 +657,52 @@ func TestDoRetriesTransportError(t *testing.T) {
 	}
 }
 
+func TestDoRetriesTransportErrorForReadOnlyPost(t *testing.T) {
+	for _, path := range []string{"/search", "/databases/db1/query", "/data_sources/ds1/query"} {
+		t.Run(path, func(t *testing.T) {
+			attempts := 0
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				attempts++
+				if attempts == 1 {
+					return nil, errors.New("read: connection reset by peer")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"object":"list","results":[],"has_more":false}`)),
+					Request:    req,
+				}, nil
+			})}
+
+			var out map[string]any
+			err := (Client{BaseURL: "https://api.notion.com/v1", Version: "2022-06-28", Token: "secret", HTTP: client}).do(context.Background(), http.MethodPost, path, map[string]any{"page_size": 100}, &out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if attempts != 2 {
+				t.Fatalf("expected 2 attempts, got %d", attempts)
+			}
+		})
+	}
+}
+
+func TestDoDoesNotRetryTransportErrorForUnknownPost(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		return nil, errors.New("read: connection reset by peer")
+	})}
+
+	var out map[string]any
+	err := (Client{BaseURL: "https://api.notion.com/v1", Version: "2022-06-28", Token: "secret", HTTP: client}).do(context.Background(), http.MethodPost, "/pages", map[string]any{"title": "example"}, &out)
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected one attempt for unknown POST, got %d", attempts)
+	}
+}
+
 func TestIngestCommentsRetriesTransientGatewayError(t *testing.T) {
 	attempts := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Retry transient transport errors returned by `http.Client.Do` inside the existing Notion API attempt loop.
- Preserve immediate failure for canceled or deadline-expired contexts.
- Add regression coverage for a one-shot `read: connection reset by peer` failure followed by a successful retry.

## Why

During a long Notion API sync, a block-children request failed with:

```text
Get "https://api.notion.com/v1/blocks/.../children?page_size=100": read tcp ...: read: connection reset by peer
```

The current retry path handles retryable HTTP responses such as 502/503/504/524, but transport errors from `http.Client.Do` return immediately and abort the whole sync. A reset from Notion or an intermediate proxy is transient enough to retry under the same attempt budget.

## Test

```text
go test ./...
```
