### PR TITLE
fix(share): preserve local rows during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.4 - Unreleased
 
+- Merge git-share imports without pruning local rows or tombstones, with explicit `--restore` replacement and optional `--retain-revisions` history.
+
 ## 0.5.3 - 2026-07-17
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Default paths:
 - `tui` opens the terminal archive browser for pages and databases
 - `sql` runs read-only SQL against the archive
 - `publish` exports SQLite tables and Markdown into a git share repo; `--tag` names an immutable checkpoint
-- `subscribe` clones a share repo and imports the latest snapshot
-- `update` pulls and imports a subscribed share repo; `--ref` imports a historical tag, commit, or branch without changing the checkout
+- `subscribe` clones a share repo and merges the latest snapshot into local rows; `--restore` opts into exact replacement and `--retain-revisions` saves replaced local payloads in the local-only `record_revisions` table
+- `update` merges current or `--ref` historical share data without changing the checkout; `--restore` and `--retain-revisions` select the same retention modes
 
 ## Shared crawlkit surfaces
 

--- a/cmd/notcrawl/main.go
+++ b/cmd/notcrawl/main.go
@@ -1341,9 +1341,15 @@ func runPublish(ctx context.Context, stdout io.Writer, cfg config.Config, args [
 
 func runSubscribe(ctx context.Context, stdout io.Writer, cfg config.Config, args []string) error {
 	fs := flag.NewFlagSet("subscribe", flag.ContinueOnError)
+	fs.SetOutput(stdout)
 	repo := fs.String("repo", cfg.Share.RepoPath, "share repo path")
 	branch := fs.String("branch", cfg.Share.Branch, "share branch")
+	restore := fs.Bool("restore", false, "replace the local archive exactly, removing rows absent from the snapshot")
+	retainRevisions := fs.Bool("retain-revisions", false, "save replaced local rows in record_revisions")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
 		return err
 	}
 	remote := cfg.Share.Remote
@@ -1355,20 +1361,30 @@ func runSubscribe(ctx context.Context, stdout io.Writer, cfg config.Config, args
 		return err
 	}
 	defer st.Close()
-	manifest, err := share.Subscribe(ctx, st, remote, *repo, *branch)
+	result, err := share.SubscribeWithOptions(ctx, st, remote, *repo, *branch, share.ImportOptions{
+		Restore:         *restore,
+		RetainRevisions: *retainRevisions,
+	})
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "subscribed %s tables=%d generated_at=%s\n", remote, len(manifest.Tables), manifest.GeneratedAt)
+	fmt.Fprintf(stdout, "subscribed %s mode=%s revisions=%d tables=%d generated_at=%s\n",
+		remote, result.Mode, result.Revisions, len(result.Manifest.Tables), result.Manifest.GeneratedAt)
 	return nil
 }
 
 func runUpdate(ctx context.Context, stdout io.Writer, cfg config.Config, args []string) error {
 	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.SetOutput(stdout)
 	repo := fs.String("repo", cfg.Share.RepoPath, "share repo path")
 	branch := fs.String("branch", cfg.Share.Branch, "share branch")
 	ref := fs.String("ref", "", "historical tag, commit, or branch")
+	restore := fs.Bool("restore", false, "replace the local archive exactly, removing rows absent from the snapshot")
+	retainRevisions := fs.Bool("retain-revisions", false, "save replaced local rows in record_revisions")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
 		return err
 	}
 	st, err := store.Open(cfg.DBPath)
@@ -1376,14 +1392,19 @@ func runUpdate(ctx context.Context, stdout io.Writer, cfg config.Config, args []
 		return err
 	}
 	defer st.Close()
-	manifest, resolvedRef, err := share.UpdateAt(ctx, st, cfg.Share.Remote, *repo, *branch, *ref)
+	result, resolvedRef, err := share.UpdateAtWithOptions(ctx, st, cfg.Share.Remote, *repo, *branch, *ref, share.ImportOptions{
+		Restore:         *restore,
+		RetainRevisions: *retainRevisions,
+	})
 	if err != nil {
 		return err
 	}
 	if resolvedRef == "" {
-		fmt.Fprintf(stdout, "updated tables=%d generated_at=%s\n", len(manifest.Tables), manifest.GeneratedAt)
+		fmt.Fprintf(stdout, "updated mode=%s revisions=%d tables=%d generated_at=%s\n",
+			result.Mode, result.Revisions, len(result.Manifest.Tables), result.Manifest.GeneratedAt)
 	} else {
-		fmt.Fprintf(stdout, "updated ref=%s tables=%d generated_at=%s\n", resolvedRef, len(manifest.Tables), manifest.GeneratedAt)
+		fmt.Fprintf(stdout, "updated ref=%s mode=%s revisions=%d tables=%d generated_at=%s\n",
+			resolvedRef, result.Mode, result.Revisions, len(result.Manifest.Tables), result.Manifest.GeneratedAt)
 	}
 	return nil
 }
@@ -1512,7 +1533,9 @@ Commands:
   sql QUERY                 Run read-only SQL
   publish [--push] [--tag NAME]
                             Export data and Markdown into a git share repo
-  subscribe REMOTE          Clone/import a git share repo
-  update [--ref REF]        Pull/import current or historical git share data
+  subscribe [--restore] [--retain-revisions] REMOTE
+                            Clone and merge a git share repo
+  update [--ref REF] [--restore] [--retain-revisions]
+                            Pull and merge current or historical git share data
 `)
 }

--- a/cmd/notcrawl/main_test.go
+++ b/cmd/notcrawl/main_test.go
@@ -391,6 +391,30 @@ func TestMetadataDoesNotMarkPlainTextCommandsAsJSON(t *testing.T) {
 	}
 }
 
+func TestShareImportHelpDocumentsRetentionModes(t *testing.T) {
+	for _, command := range []struct {
+		name string
+		run  func(*bytes.Buffer) error
+	}{
+		{name: "subscribe", run: func(stdout *bytes.Buffer) error {
+			return runSubscribe(context.Background(), stdout, config.Config{}, []string{"--help"})
+		}},
+		{name: "update", run: func(stdout *bytes.Buffer) error {
+			return runUpdate(context.Background(), stdout, config.Config{}, []string{"--help"})
+		}},
+	} {
+		var stdout bytes.Buffer
+		if err := command.run(&stdout); err != nil {
+			t.Fatalf("%s help: %v", command.name, err)
+		}
+		for _, flag := range []string{"-restore", "-retain-revisions"} {
+			if !strings.Contains(stdout.String(), flag) {
+				t.Fatalf("%s help missing %s:\n%s", command.name, flag, stdout.String())
+			}
+		}
+	}
+}
+
 func TestSyncEmitsProgressPercentToStderr(t *testing.T) {
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -61,6 +61,17 @@ type PublishSummary struct {
 	Tag       string
 }
 
+type ImportOptions struct {
+	Restore         bool
+	RetainRevisions bool
+}
+
+type ImportResult struct {
+	Manifest  Manifest
+	Mode      string
+	Revisions int
+}
+
 func Publish(ctx context.Context, st *store.Store, opts PublishOptions) (PublishSummary, error) {
 	if opts.RepoPath == "" {
 		return PublishSummary{}, fmt.Errorf("missing share repo path")
@@ -175,59 +186,76 @@ func Publish(ctx context.Context, st *store.Store, opts PublishOptions) (Publish
 }
 
 func Import(ctx context.Context, st *store.Store, repoPath string) (Manifest, error) {
+	result, err := ImportWithOptions(ctx, st, repoPath, ImportOptions{})
+	return result.Manifest, err
+}
+
+func ImportWithOptions(ctx context.Context, st *store.Store, repoPath string, opts ImportOptions) (ImportResult, error) {
 	b, err := os.ReadFile(filepath.Join(repoPath, "manifest.json"))
 	if err != nil {
-		return Manifest{}, err
+		return ImportResult{}, err
 	}
 	var manifest Manifest
 	if err := json.Unmarshal(b, &manifest); err != nil {
-		return Manifest{}, err
+		return ImportResult{}, err
 	}
 	if err := validateManifest(repoPath, manifest); err != nil {
-		return manifest, err
+		return ImportResult{Manifest: manifest}, err
 	}
-	tx, err := st.DB().BeginTx(ctx, nil)
+	result := ImportResult{Manifest: manifest, Mode: "merge"}
+	err = st.WithSQLTransaction(ctx, func(tx *sql.Tx) error {
+		if opts.Restore {
+			result.Mode = "restore"
+			if opts.RetainRevisions {
+				var err error
+				result.Revisions, err = retainAllImportRevisions(ctx, tx, "snapshot-restore")
+				if err != nil {
+					return err
+				}
+			}
+			if _, err := tx.ExecContext(ctx, `delete from record_sources`); err != nil {
+				return err
+			}
+			for _, table := range exportTables {
+				if _, err := tx.ExecContext(ctx, "delete from "+quoteIdent(table)); err != nil {
+					return err
+				}
+			}
+		}
+		for _, table := range manifest.Tables {
+			rows, revisions, err := importTable(ctx, st, tx, filepath.Join(repoPath, table.Path), table.Name, opts)
+			if err != nil {
+				return err
+			}
+			result.Revisions += revisions
+			if rows != table.Rows {
+				return fmt.Errorf("snapshot table %s row count mismatch: manifest=%d imported=%d", table.Name, table.Rows, rows)
+			}
+		}
+		if manifest.RecordSources != nil {
+			rows, revisions, err := importTable(ctx, st, tx, filepath.Join(repoPath, manifest.RecordSources.Path), "record_sources", opts)
+			if err != nil {
+				return err
+			}
+			result.Revisions += revisions
+			if rows != manifest.RecordSources.Rows {
+				return fmt.Errorf("record_sources row count mismatch: manifest=%d imported=%d", manifest.RecordSources.Rows, rows)
+			}
+		} else if err := rebuildRecordSources(ctx, tx); err != nil {
+			return err
+		}
+		if err := normalizeImportedTombstones(ctx, tx); err != nil {
+			return err
+		}
+		return reconcileImportedAlive(ctx, tx)
+	})
 	if err != nil {
-		return manifest, err
-	}
-	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx, `delete from record_sources`); err != nil {
-		return manifest, err
-	}
-	for _, table := range exportTables {
-		if _, err := tx.ExecContext(ctx, "delete from "+quoteIdent(table)); err != nil {
-			return manifest, err
-		}
-	}
-	for _, table := range manifest.Tables {
-		rows, err := importTable(ctx, tx, filepath.Join(repoPath, table.Path), table.Name)
-		if err != nil {
-			return manifest, err
-		}
-		if rows != table.Rows {
-			return manifest, fmt.Errorf("snapshot table %s row count mismatch: manifest=%d imported=%d", table.Name, table.Rows, rows)
-		}
-	}
-	if manifest.RecordSources != nil {
-		rows, err := importTable(ctx, tx, filepath.Join(repoPath, manifest.RecordSources.Path), "record_sources")
-		if err != nil {
-			return manifest, err
-		}
-		if rows != manifest.RecordSources.Rows {
-			return manifest, fmt.Errorf("record_sources row count mismatch: manifest=%d imported=%d", manifest.RecordSources.Rows, rows)
-		}
-	} else {
-		if err := rebuildRecordSources(ctx, tx); err != nil {
-			return manifest, err
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return manifest, err
+		return result, err
 	}
 	if err := st.RebuildFTS(ctx); err != nil {
-		return manifest, err
+		return result, err
 	}
-	return manifest, nil
+	return result, nil
 }
 
 func validateManifest(repoPath string, manifest Manifest) error {
@@ -339,17 +367,17 @@ func validateManifestFile(repoPath, path string) error {
 	return nil
 }
 
-func Subscribe(ctx context.Context, st *store.Store, remote, repoPath, branch string) (Manifest, error) {
+func SubscribeWithOptions(ctx context.Context, st *store.Store, remote, repoPath, branch string, importOpts ImportOptions) (ImportResult, error) {
 	if remote == "" {
-		return Manifest{}, fmt.Errorf("missing share remote")
+		return ImportResult{}, fmt.Errorf("missing share remote")
 	}
 	if branch == "" {
 		branch = "main"
 	}
 	if err := mirror.Pull(ctx, mirror.Options{RepoPath: repoPath, Remote: remote, Branch: branch}); err != nil {
-		return Manifest{}, err
+		return ImportResult{}, err
 	}
-	return Import(ctx, st, repoPath)
+	return ImportWithOptions(ctx, st, repoPath, importOpts)
 }
 
 func Update(ctx context.Context, st *store.Store, remote, repoPath, branch string) (Manifest, error) {
@@ -358,31 +386,36 @@ func Update(ctx context.Context, st *store.Store, remote, repoPath, branch strin
 }
 
 func UpdateAt(ctx context.Context, st *store.Store, remote, repoPath, branch, ref string) (Manifest, string, error) {
+	result, resolved, err := UpdateAtWithOptions(ctx, st, remote, repoPath, branch, ref, ImportOptions{})
+	return result.Manifest, resolved, err
+}
+
+func UpdateAtWithOptions(ctx context.Context, st *store.Store, remote, repoPath, branch, ref string, importOpts ImportOptions) (ImportResult, string, error) {
 	if branch == "" {
 		branch = "main"
 	}
 	if strings.TrimSpace(ref) != "" {
 		opts := mirror.Options{RepoPath: repoPath, Remote: remote, Branch: branch}
 		if err := mirror.Fetch(ctx, opts); err != nil {
-			return Manifest{}, "", err
+			return ImportResult{}, "", err
 		}
-		return importAtRef(ctx, st, opts, ref)
+		return importAtRef(ctx, st, opts, ref, importOpts)
 	}
 	if err := pullForUpdate(ctx, repoPath, remote, branch); err != nil {
-		return Manifest{}, "", err
+		return ImportResult{}, "", err
 	}
-	manifest, err := Import(ctx, st, repoPath)
-	return manifest, "", err
+	result, err := ImportWithOptions(ctx, st, repoPath, importOpts)
+	return result, "", err
 }
 
-func importAtRef(ctx context.Context, st *store.Store, opts mirror.Options, ref string) (Manifest, string, error) {
+func importAtRef(ctx context.Context, st *store.Store, opts mirror.Options, ref string, importOpts ImportOptions) (ImportResult, string, error) {
 	body, commit, err := mirror.ReadFileAt(ctx, opts, ref, "manifest.json")
 	if err != nil {
-		return Manifest{}, "", err
+		return ImportResult{}, "", err
 	}
 	var manifest Manifest
 	if err := json.Unmarshal(body, &manifest); err != nil {
-		return Manifest{}, "", err
+		return ImportResult{}, "", err
 	}
 	for i := range manifest.Tables {
 		manifest.Tables[i].Path = filepath.ToSlash(manifest.Tables[i].Path)
@@ -391,19 +424,19 @@ func importAtRef(ctx context.Context, st *store.Store, opts mirror.Options, ref 
 		manifest.RecordSources.Path = filepath.ToSlash(manifest.RecordSources.Path)
 	}
 	if err := validateManifestShape(manifest); err != nil {
-		return manifest, "", err
+		return ImportResult{Manifest: manifest}, "", err
 	}
 	temp, err := os.MkdirTemp("", "notcrawl-share-ref-*")
 	if err != nil {
-		return manifest, "", err
+		return ImportResult{Manifest: manifest}, "", err
 	}
 	defer func() { _ = os.RemoveAll(temp) }()
 	manifestBody, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
-		return manifest, "", err
+		return ImportResult{Manifest: manifest}, "", err
 	}
 	if err := os.WriteFile(filepath.Join(temp, "manifest.json"), append(manifestBody, '\n'), 0o600); err != nil {
-		return manifest, "", err
+		return ImportResult{Manifest: manifest}, "", err
 	}
 	tables := append([]TableManifest(nil), manifest.Tables...)
 	if manifest.RecordSources != nil {
@@ -412,20 +445,20 @@ func importAtRef(ctx context.Context, st *store.Store, opts mirror.Options, ref 
 	for _, table := range tables {
 		data, resolved, err := mirror.ReadFileAt(ctx, opts, commit, table.Path)
 		if err != nil {
-			return manifest, "", err
+			return ImportResult{Manifest: manifest}, "", err
 		}
 		if resolved != commit {
-			return manifest, "", fmt.Errorf("share ref changed while reading %s", table.Path)
+			return ImportResult{Manifest: manifest}, "", fmt.Errorf("share ref changed while reading %s", table.Path)
 		}
 		target := filepath.Join(temp, filepath.FromSlash(table.Path))
 		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
-			return manifest, "", err
+			return ImportResult{Manifest: manifest}, "", err
 		}
 		if err := os.WriteFile(target, data, 0o600); err != nil {
-			return manifest, "", err
+			return ImportResult{Manifest: manifest}, "", err
 		}
 	}
-	imported, err := Import(ctx, st, temp)
+	imported, err := ImportWithOptions(ctx, st, temp, importOpts)
 	return imported, commit, err
 }
 
@@ -478,64 +511,444 @@ type sqlExecer interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
-func importTable(ctx context.Context, db sqlExecer, path, table string) (int, error) {
+var importPrimaryKeys = map[string][]string{
+	"spaces":         {"id"},
+	"users":          {"id"},
+	"teams":          {"id"},
+	"pages":          {"id"},
+	"blocks":         {"id"},
+	"collections":    {"id"},
+	"comments":       {"id"},
+	"raw_records":    {"source", "record_table", "record_id"},
+	"sync_state":     {"source", "entity_type", "entity_id"},
+	"record_sources": {"record_table", "record_id", "source"},
+}
+
+var revisionTables = []string{
+	"spaces",
+	"users",
+	"teams",
+	"pages",
+	"blocks",
+	"collections",
+	"comments",
+	"raw_records",
+	"record_sources",
+}
+
+func importTable(ctx context.Context, st *store.Store, db *sql.Tx, path, table string, opts ImportOptions) (int, int, error) {
 	in, err := os.Open(path)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	defer in.Close()
 	gz, err := gzip.NewReader(in)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	defer gz.Close()
-	if _, err := db.ExecContext(ctx, "delete from "+quoteIdent(table)); err != nil {
-		return 0, err
-	}
 	scanner := bufio.NewScanner(gz)
 	buf := make([]byte, 0, 1024*1024)
 	scanner.Buffer(buf, 32*1024*1024)
 	count := 0
+	revisions := 0
 	for scanner.Scan() {
 		var row map[string]any
 		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
-			return count, err
+			return count, revisions, err
 		}
 		if len(row) == 0 {
 			continue
 		}
-		cols := make([]string, 0, len(row))
-		for col := range row {
-			cols = append(cols, col)
+		count++
+		if _, err := importRecordKey(table, row); err != nil {
+			return count, revisions, err
 		}
-		sort.Strings(cols)
-		args := make([]any, 0, len(cols))
-		holders := make([]string, 0, len(cols))
-		quotedCols := make([]string, 0, len(cols))
-		for _, col := range cols {
-			quotedCols = append(quotedCols, quoteIdent(col))
-			holders = append(holders, "?")
-			args = append(args, row[col])
+		if !opts.Restore {
+			preserve, err := preserveLocalTombstone(ctx, db, table, row)
+			if err != nil {
+				return count, revisions, err
+			}
+			if preserve {
+				continue
+			}
 		}
-		stmt := fmt.Sprintf("insert or replace into %s(%s) values(%s)", quoteIdent(table), strings.Join(quotedCols, ","), strings.Join(holders, ","))
-		if _, err := db.ExecContext(ctx, stmt, args...); err != nil {
+		var previous map[string]any
+		if opts.RetainRevisions && !opts.Restore && tableRetainsRevisions(table) {
+			previous, _, err = existingImportRow(ctx, db, table, row)
+			if err != nil {
+				return count, revisions, err
+			}
+		}
+		if !opts.Restore && canonicalImportTable(table) {
+			if err := importCanonicalRow(ctx, st, table, row); err != nil {
+				return count, revisions, err
+			}
+		} else {
+			cols := make([]string, 0, len(row))
+			for col := range row {
+				cols = append(cols, col)
+			}
+			sort.Strings(cols)
+			args := make([]any, 0, len(cols))
+			holders := make([]string, 0, len(cols))
+			quotedCols := make([]string, 0, len(cols))
+			for _, col := range cols {
+				quotedCols = append(quotedCols, quoteIdent(col))
+				holders = append(holders, "?")
+				args = append(args, row[col])
+			}
+			stmt, err := importInsertStatement(table, cols, quotedCols, holders, opts.Restore)
+			if err != nil {
+				return count, revisions, err
+			}
+			if _, err := db.ExecContext(ctx, stmt, args...); err != nil {
+				return count, revisions, err
+			}
+		}
+		if previous != nil {
+			retained, err := retainChangedRevision(ctx, db, table, row, previous, "snapshot-merge")
+			if err != nil {
+				return count, revisions, err
+			}
+			if retained {
+				revisions++
+			}
+		}
+	}
+	return count, revisions, scanner.Err()
+}
+
+func importInsertStatement(table string, cols, quotedCols, holders []string, restore bool) (string, error) {
+	base := fmt.Sprintf("insert into %s(%s) values(%s)", quoteIdent(table), strings.Join(quotedCols, ","), strings.Join(holders, ","))
+	if restore {
+		return base, nil
+	}
+	keys, ok := importPrimaryKeys[table]
+	if !ok {
+		return "", fmt.Errorf("missing import key for table %q", table)
+	}
+	keySet := make(map[string]bool, len(keys))
+	quotedKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		keySet[key] = true
+		quotedKeys = append(quotedKeys, quoteIdent(key))
+	}
+	updates := make([]string, 0, len(cols)-len(keys))
+	for _, col := range cols {
+		if !keySet[col] {
+			if table == "record_sources" && col == "payload_json" {
+				updates = append(updates, `"payload_json" = case when excluded."alive" = 0 then null else coalesce(excluded."payload_json", "record_sources"."payload_json") end`)
+			} else {
+				updates = append(updates, quoteIdent(col)+" = excluded."+quoteIdent(col))
+			}
+		}
+	}
+	if len(updates) == 0 {
+		return base + " on conflict(" + strings.Join(quotedKeys, ",") + ") do nothing", nil
+	}
+	return base + " on conflict(" + strings.Join(quotedKeys, ",") + ") do update set " + strings.Join(updates, ","), nil
+}
+
+func preserveLocalTombstone(ctx context.Context, db *sql.Tx, table string, row map[string]any) (bool, error) {
+	recordTable := ""
+	switch table {
+	case "pages":
+		recordTable = "page"
+	case "blocks":
+		recordTable = "block"
+	case "comments":
+		recordTable = "comment"
+	case "record_sources":
+		recordTable, _ = row["record_table"].(string)
+	default:
+		return false, nil
+	}
+	recordID, _ := row["id"].(string)
+	if table == "record_sources" {
+		recordID, _ = row["record_id"].(string)
+	}
+	source, _ := row["source"].(string)
+	if recordTable == "" || recordID == "" || source == "" {
+		return false, nil
+	}
+	var alive int
+	err := db.QueryRowContext(ctx, `select alive from record_sources
+		where record_table = ? and record_id = ? and source = ?`, recordTable, recordID, source).Scan(&alive)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return alive == 0, nil
+}
+
+func tableRetainsRevisions(table string) bool {
+	for _, candidate := range revisionTables {
+		if table == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func retainChangedRevision(ctx context.Context, db *sql.Tx, table string, incoming, previous map[string]any, reason string) (bool, error) {
+	current, ok, err := existingImportRow(ctx, db, table, incoming)
+	if err != nil || !ok {
+		return false, err
+	}
+	previousJSON, err := json.Marshal(previous)
+	if err != nil {
+		return false, err
+	}
+	currentJSON, err := json.Marshal(current)
+	if err != nil {
+		return false, err
+	}
+	if string(previousJSON) == string(currentJSON) {
+		return false, nil
+	}
+	key, err := importRecordKey(table, incoming)
+	if err != nil {
+		return false, err
+	}
+	if _, err := db.ExecContext(ctx, `insert into record_revisions(
+		record_table, record_key, payload_json, recorded_at, event_source, reason)
+		values (?, ?, ?, ?, 'share-import', ?)`, table, key, string(previousJSON), store.NowMS(), reason); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func canonicalImportTable(table string) bool {
+	switch table {
+	case "pages", "blocks", "comments":
+		return true
+	default:
+		return false
+	}
+}
+
+func importCanonicalRow(ctx context.Context, st *store.Store, table string, row map[string]any) error {
+	switch table {
+	case "pages":
+		return st.UpsertPage(ctx, store.Page{
+			ID: rowString(row, "id"), SpaceID: rowString(row, "space_id"), ParentID: rowString(row, "parent_id"),
+			ParentTable: rowString(row, "parent_table"), CollectionID: rowString(row, "collection_id"), Title: rowString(row, "title"),
+			URL: rowString(row, "url"), Icon: rowString(row, "icon"), Cover: rowString(row, "cover"), PropertiesJSON: rowString(row, "properties_json"),
+			CreatedTime: rowInt64(row, "created_time"), LastEditedTime: rowInt64(row, "last_edited_time"), Alive: rowBool(row, "alive"),
+			Source: rowString(row, "source"), RawJSON: rowString(row, "raw_json"), SyncedAt: rowInt64(row, "synced_at"),
+		})
+	case "blocks":
+		return st.UpsertBlock(ctx, store.Block{
+			ID: rowString(row, "id"), PageID: rowString(row, "page_id"), SpaceID: rowString(row, "space_id"), ParentID: rowString(row, "parent_id"),
+			ParentTable: rowString(row, "parent_table"), Type: rowString(row, "type"), Text: rowString(row, "text"),
+			PropertiesJSON: rowString(row, "properties_json"), ContentJSON: rowString(row, "content_json"), FormatJSON: rowString(row, "format_json"),
+			DisplayOrder: rowInt64(row, "display_order"), CreatedTime: rowInt64(row, "created_time"), LastEditedTime: rowInt64(row, "last_edited_time"),
+			Alive: rowBool(row, "alive"), Source: rowString(row, "source"), RawJSON: rowString(row, "raw_json"), SyncedAt: rowInt64(row, "synced_at"),
+		})
+	case "comments":
+		return st.UpsertComment(ctx, store.Comment{
+			ID: rowString(row, "id"), PageID: rowString(row, "page_id"), SpaceID: rowString(row, "space_id"), ParentID: rowString(row, "parent_id"),
+			Text: rowString(row, "text"), CreatedByID: rowString(row, "created_by_id"), CreatedTime: rowInt64(row, "created_time"),
+			LastEditedTime: rowInt64(row, "last_edited_time"), Alive: rowBool(row, "alive"), RawJSON: rowString(row, "raw_json"),
+			Source: rowString(row, "source"), SyncedAt: rowInt64(row, "synced_at"),
+		})
+	default:
+		return fmt.Errorf("unsupported canonical import table %q", table)
+	}
+}
+
+func rowString(row map[string]any, key string) string {
+	value, _ := row[key].(string)
+	return value
+}
+
+func rowInt64(row map[string]any, key string) int64 {
+	switch value := row[key].(type) {
+	case float64:
+		return int64(value)
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	default:
+		return 0
+	}
+}
+
+func rowBool(row map[string]any, key string) bool {
+	return rowInt64(row, key) != 0
+}
+
+func existingImportRow(ctx context.Context, db *sql.Tx, table string, incoming map[string]any) (map[string]any, bool, error) {
+	keys, ok := importPrimaryKeys[table]
+	if !ok {
+		return nil, false, fmt.Errorf("missing import key for table %q", table)
+	}
+	clauses := make([]string, 0, len(keys))
+	args := make([]any, 0, len(keys))
+	for _, key := range keys {
+		value, exists := incoming[key]
+		if !exists {
+			return nil, false, fmt.Errorf("snapshot table %s row missing key %q", table, key)
+		}
+		clauses = append(clauses, quoteIdent(key)+" = ?")
+		args = append(args, value)
+	}
+	rows, err := db.QueryContext(ctx, "select * from "+quoteIdent(table)+" where "+strings.Join(clauses, " and "), args...)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, false, rows.Err()
+	}
+	row, err := scanImportRow(rows)
+	return row, true, err
+}
+
+func scanImportRow(rows *sql.Rows) (map[string]any, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+	values := make([]any, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range values {
+		ptrs[i] = &values[i]
+	}
+	if err := rows.Scan(ptrs...); err != nil {
+		return nil, err
+	}
+	row := make(map[string]any, len(cols))
+	for i, col := range cols {
+		row[col] = exportValue(values[i])
+	}
+	return row, nil
+}
+
+func importRecordKey(table string, row map[string]any) (string, error) {
+	keys, ok := importPrimaryKeys[table]
+	if !ok {
+		return "", fmt.Errorf("missing import key for table %q", table)
+	}
+	key := make(map[string]any, len(keys))
+	for _, name := range keys {
+		value, exists := row[name]
+		if !exists || value == nil || value == "" {
+			return "", fmt.Errorf("snapshot table %s row missing key %q", table, name)
+		}
+		key[name] = value
+	}
+	body, err := json.Marshal(key)
+	return string(body), err
+}
+
+func retainAllImportRevisions(ctx context.Context, db *sql.Tx, reason string) (int, error) {
+	type revision struct {
+		table   string
+		key     string
+		payload string
+	}
+	count := 0
+	for _, table := range revisionTables {
+		rows, err := db.QueryContext(ctx, "select * from "+quoteIdent(table))
+		if err != nil {
 			return count, err
 		}
-		count++
+		var pending []revision
+		for rows.Next() {
+			row, err := scanImportRow(rows)
+			if err != nil {
+				rows.Close()
+				return count, err
+			}
+			key, err := importRecordKey(table, row)
+			if err != nil {
+				rows.Close()
+				return count, err
+			}
+			payload, err := json.Marshal(row)
+			if err != nil {
+				rows.Close()
+				return count, err
+			}
+			pending = append(pending, revision{table: table, key: key, payload: string(payload)})
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return count, err
+		}
+		if err := rows.Close(); err != nil {
+			return count, err
+		}
+		for _, item := range pending {
+			if _, err := db.ExecContext(ctx, `insert into record_revisions(
+				record_table, record_key, payload_json, recorded_at, event_source, reason)
+				values (?, ?, ?, ?, 'share-import', ?)`, item.table, item.key, item.payload, store.NowMS(), reason); err != nil {
+				return count, err
+			}
+			count++
+		}
 	}
-	return count, scanner.Err()
+	return count, nil
 }
 
 func rebuildRecordSources(ctx context.Context, db sqlExecer) error {
 	for _, stmt := range []string{
-		`insert into record_sources(record_table, record_id, source, synced_at, alive)
-			select 'page', id, source, synced_at, alive from pages`,
-		`insert into record_sources(record_table, record_id, source, synced_at, alive)
-			select 'block', id, source, synced_at, alive from blocks`,
-		`insert into record_sources(record_table, record_id, source, synced_at, alive)
-			select 'comment', id, source, synced_at, alive from comments`,
+		`insert or ignore into record_sources(
+			record_table, record_id, source, synced_at, alive, deleted_at, deletion_source, deletion_reason)
+			select 'page', id, source, synced_at, alive,
+				case when alive = 0 then synced_at end,
+				case when alive = 0 then source end,
+				case when alive = 0 then 'snapshot-legacy-tombstone' end
+			from pages`,
+		`insert or ignore into record_sources(
+			record_table, record_id, source, synced_at, alive, deleted_at, deletion_source, deletion_reason)
+			select 'block', id, source, synced_at, alive,
+				case when alive = 0 then synced_at end,
+				case when alive = 0 then source end,
+				case when alive = 0 then 'snapshot-legacy-tombstone' end
+			from blocks`,
+		`insert or ignore into record_sources(
+			record_table, record_id, source, synced_at, alive, deleted_at, deletion_source, deletion_reason)
+			select 'comment', id, source, synced_at, alive,
+				case when alive = 0 then synced_at end,
+				case when alive = 0 then source end,
+				case when alive = 0 then 'snapshot-legacy-tombstone' end
+			from comments`,
 	} {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeImportedTombstones(ctx context.Context, db sqlExecer) error {
+	_, err := db.ExecContext(ctx, `update record_sources set
+		deleted_at = coalesce(deleted_at, synced_at),
+		deletion_source = coalesce(deletion_source, source),
+		deletion_reason = coalesce(deletion_reason, 'snapshot-legacy-tombstone')
+		where alive = 0`)
+	return err
+}
+
+func reconcileImportedAlive(ctx context.Context, db sqlExecer) error {
+	for recordTable, table := range map[string]string{
+		"page":    "pages",
+		"block":   "blocks",
+		"comment": "comments",
+	} {
+		if _, err := db.ExecContext(ctx, `update `+quoteIdent(table)+` set alive = exists(
+			select 1 from record_sources
+			where record_table = ? and record_id = `+quoteIdent(table)+`.id and alive = 1
+		) where exists(
+			select 1 from record_sources
+			where record_table = ? and record_id = `+quoteIdent(table)+`.id
+		)`, recordTable, recordTable); err != nil {
 			return err
 		}
 	}

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -293,6 +293,9 @@ func TestImportMergePreservesLocalRowsAndTombstonesWithOptionalRevisions(t *test
 	if err := dst.UpsertSpace(ctx, store.Space{ID: "space1", Name: "Local space", RawJSON: `{"name":"local"}`, Source: "desktop", SyncedAt: now}); err != nil {
 		t.Fatal(err)
 	}
+	if err := dst.UpsertSpace(ctx, store.Space{ID: "rowid-sentinel", Name: "Sentinel", Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
 	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Local deleted", Alive: true, Source: "test", SyncedAt: now}); err != nil {
 		t.Fatal(err)
 	}
@@ -300,6 +303,10 @@ func TestImportMergePreservesLocalRowsAndTombstonesWithOptionalRevisions(t *test
 		t.Fatal(err)
 	}
 	if err := dst.UpsertPage(ctx, store.Page{ID: "local-only", Title: "Local only", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	var spaceRowID int64
+	if err := dst.DB().QueryRowContext(ctx, `select rowid from spaces where id = 'space1'`).Scan(&spaceRowID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -341,6 +348,13 @@ func TestImportMergePreservesLocalRowsAndTombstonesWithOptionalRevisions(t *test
 	}
 	if spaceName != "Remote space" {
 		t.Fatalf("merged space name = %q", spaceName)
+	}
+	var mergedSpaceRowID int64
+	if err := dst.DB().QueryRowContext(ctx, `select rowid from spaces where id = 'space1'`).Scan(&mergedSpaceRowID); err != nil {
+		t.Fatal(err)
+	}
+	if mergedSpaceRowID != spaceRowID {
+		t.Fatalf("merge replaced stable space rowid: before=%d after=%d", spaceRowID, mergedSpaceRowID)
 	}
 	var revisionPayload string
 	if err := dst.DB().QueryRowContext(ctx, `select payload_json from record_revisions

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -204,8 +204,240 @@ func TestImportLegacySnapshotRebuildsSourceProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pages) != 1 || pages[0].ID != "page1" {
-		t.Fatalf("legacy import retained stale destination rows: %#v", pages)
+	if len(pages) != 2 {
+		t.Fatalf("legacy merge removed destination rows: %#v", pages)
+	}
+	seen := map[string]bool{}
+	for _, page := range pages {
+		seen[page.ID] = true
+	}
+	if !seen["page1"] || !seen["stale"] {
+		t.Fatalf("legacy merge pages = %#v", pages)
+	}
+}
+
+func TestImportRestoreReplacesDestinationAndTombstoneState(t *testing.T) {
+	ctx := context.Background()
+	src, mdDir := snapshotStoreForTest(t, ctx, "Remote live", "remote body")
+	defer src.Close()
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	now := store.NowMS()
+	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Local deleted", Alive: true, Source: "test", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Local deleted", Alive: false, Source: "test", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.UpsertPage(ctx, store.Page{ID: "local-only", Title: "Local only", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ImportWithOptions(ctx, dst, repo, ImportOptions{Restore: true, RetainRevisions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Mode != "restore" || result.Revisions != 4 {
+		t.Fatalf("import result = %+v", result)
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].ID != "page1" || pages[0].Title != "Remote live" || !pages[0].Alive {
+		t.Fatalf("restored pages = %#v", pages)
+	}
+	exists, alive, err := dst.RecordSourceState(ctx, "page", "page1", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists || !alive {
+		t.Fatalf("restored source state: exists=%v alive=%v", exists, alive)
+	}
+	var removedRevision string
+	if err := dst.DB().QueryRowContext(ctx, `select payload_json from record_revisions
+		where record_table = 'pages' and record_key like '%local-only%' and reason = 'snapshot-restore'`).Scan(&removedRevision); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(removedRevision, "Local only") {
+		t.Fatalf("restore revision payload = %s", removedRevision)
+	}
+}
+
+func TestImportMergePreservesLocalRowsAndTombstonesWithOptionalRevisions(t *testing.T) {
+	ctx := context.Background()
+	src, mdDir := snapshotStoreForTest(t, ctx, "Remote live", "remote body")
+	defer src.Close()
+	if err := src.UpsertSpace(ctx, store.Space{ID: "space1", Name: "Remote space", RawJSON: `{"name":"remote"}`, Source: "test", SyncedAt: store.NowMS()}); err != nil {
+		t.Fatal(err)
+	}
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	now := store.NowMS()
+	if err := dst.UpsertSpace(ctx, store.Space{ID: "space1", Name: "Local space", RawJSON: `{"name":"local"}`, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Local deleted", Alive: true, Source: "test", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Local deleted", Alive: false, Source: "test", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.UpsertPage(ctx, store.Page{ID: "local-only", Title: "Local only", Alive: true, Source: "desktop", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ImportWithOptions(ctx, dst, repo, ImportOptions{RetainRevisions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Mode != "merge" || result.Revisions != 1 {
+		t.Fatalf("import result = %+v", result)
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].ID != "local-only" || pages[0].Title != "Local only" {
+		t.Fatalf("merge pages = %#v", pages)
+	}
+	var tombstonedTitle string
+	var tombstonedAlive int
+	if err := dst.DB().QueryRowContext(ctx, `select title, alive from pages where id = 'page1'`).Scan(&tombstonedTitle, &tombstonedAlive); err != nil {
+		t.Fatal(err)
+	}
+	if tombstonedAlive != 0 || tombstonedTitle != "Local deleted" {
+		t.Fatalf("local tombstone was overwritten: title=%q alive=%d", tombstonedTitle, tombstonedAlive)
+	}
+	var deletedAt int64
+	var deletionSource, deletionReason string
+	if err := dst.DB().QueryRowContext(ctx, `select deleted_at, deletion_source, deletion_reason
+		from record_sources where record_table = 'page' and record_id = 'page1' and source = 'test'`).Scan(
+		&deletedAt, &deletionSource, &deletionReason); err != nil {
+		t.Fatal(err)
+	}
+	if deletedAt != now+1 || deletionSource != "test" || deletionReason != "explicit-source-delete" {
+		t.Fatalf("tombstone metadata = %d %q %q", deletedAt, deletionSource, deletionReason)
+	}
+	var spaceName string
+	if err := dst.DB().QueryRowContext(ctx, `select name from spaces where id = 'space1'`).Scan(&spaceName); err != nil {
+		t.Fatal(err)
+	}
+	if spaceName != "Remote space" {
+		t.Fatalf("merged space name = %q", spaceName)
+	}
+	var revisionPayload string
+	if err := dst.DB().QueryRowContext(ctx, `select payload_json from record_revisions
+		where record_table = 'spaces' and reason = 'snapshot-merge'`).Scan(&revisionPayload); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(revisionPayload, "Local space") {
+		t.Fatalf("revision payload = %s", revisionPayload)
+	}
+}
+
+func TestImportMergeAppliesIncomingTombstone(t *testing.T) {
+	ctx := context.Background()
+	src, err := store.Open(filepath.Join(t.TempDir(), "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+	now := store.NowMS()
+	if err := src.UpsertPage(ctx, store.Page{ID: "page1", Title: "Remote deleted", Alive: true, Source: "api", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := src.UpsertPage(ctx, store.Page{ID: "page1", Title: "Remote deleted", Alive: false, Source: "api", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo}); err != nil {
+		t.Fatal(err)
+	}
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Local live", Alive: true, Source: "api", SyncedAt: now - 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, dst, repo); err != nil {
+		t.Fatal(err)
+	}
+	var alive int
+	if err := dst.DB().QueryRowContext(ctx, `select alive from pages where id = 'page1'`).Scan(&alive); err != nil {
+		t.Fatal(err)
+	}
+	if alive != 0 {
+		t.Fatalf("incoming tombstone alive = %d", alive)
+	}
+	var reason string
+	if err := dst.DB().QueryRowContext(ctx, `select deletion_reason from record_sources
+		where record_table = 'page' and record_id = 'page1' and source = 'api'`).Scan(&reason); err != nil {
+		t.Fatal(err)
+	}
+	if reason != "explicit-source-delete" {
+		t.Fatalf("incoming deletion reason = %q", reason)
+	}
+}
+
+func TestImportMergePreservesHigherPriorityLocalPayloadAndRemoteFallback(t *testing.T) {
+	ctx := context.Background()
+	src, mdDir := snapshotStoreForTest(t, ctx, "Remote fallback", "remote body")
+	defer src.Close()
+	repo := t.TempDir()
+	if _, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir}); err != nil {
+		t.Fatal(err)
+	}
+	dst, err := store.Open(filepath.Join(t.TempDir(), "dst.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	now := store.NowMS()
+	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Local API", Alive: true, Source: "api", SyncedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := ImportWithOptions(ctx, dst, repo, ImportOptions{RetainRevisions: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Revisions != 0 {
+		t.Fatalf("unchanged canonical payload produced revisions: %+v", result)
+	}
+	pages, err := dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].Title != "Local API" || pages[0].Source != "api" {
+		t.Fatalf("merged canonical page = %#v", pages)
+	}
+	if err := dst.UpsertPage(ctx, store.Page{ID: "page1", Title: "Deleted API", Alive: false, Source: "api", SyncedAt: now + 1}); err != nil {
+		t.Fatal(err)
+	}
+	pages, err = dst.Pages(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 1 || pages[0].Title != "Remote fallback" || pages[0].Source != "test" {
+		t.Fatalf("promoted imported fallback = %#v", pages)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ import (
 	crawlstore "github.com/openclaw/crawlkit/store"
 )
 
-const schemaVersion = 3
+const schemaVersion = 4
 
 type Store struct {
 	db               *sql.DB
@@ -81,15 +81,19 @@ func (s *Store) queryRowContext(ctx context.Context, query string, args ...any) 
 }
 
 func (s *Store) WithTransaction(ctx context.Context, fn func() error) error {
+	return s.WithSQLTransaction(ctx, func(*sql.Tx) error { return fn() })
+}
+
+func (s *Store) WithSQLTransaction(ctx context.Context, fn func(*sql.Tx) error) error {
 	if s.tx != nil {
-		return fn()
+		return fn(s.tx)
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	s.tx = tx
-	err = fn()
+	err = fn(tx)
 	s.tx = nil
 	if err != nil {
 		_ = tx.Rollback()
@@ -256,9 +260,22 @@ func (s *Store) init(ctx context.Context) error {
 			synced_at integer not null,
 			alive integer not null,
 			payload_json text,
+			deleted_at integer,
+			deletion_source text,
+			deletion_reason text,
 			primary key (record_table, record_id, source)
 		)`,
 		`create index if not exists record_sources_source_sync on record_sources(record_table, source, alive, synced_at)`,
+		`create table if not exists record_revisions (
+			id integer primary key autoincrement,
+			record_table text not null,
+			record_key text not null,
+			payload_json text not null,
+			recorded_at integer not null,
+			event_source text not null,
+			reason text not null
+		)`,
+		`create index if not exists record_revisions_record on record_revisions(record_table, record_key, recorded_at desc)`,
 		`create table if not exists sync_state (
 			source text not null,
 			entity_type text not null,
@@ -294,6 +311,15 @@ func (s *Store) init(ctx context.Context) error {
 	if err := s.ensureColumn(ctx, "record_sources", "payload_json", "text"); err != nil {
 		return err
 	}
+	if err := s.ensureColumn(ctx, "record_sources", "deleted_at", "integer"); err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, "record_sources", "deletion_source", "text"); err != nil {
+		return err
+	}
+	if err := s.ensureColumn(ctx, "record_sources", "deletion_reason", "text"); err != nil {
+		return err
+	}
 	if _, err := s.execContext(ctx, `create index if not exists blocks_page_alive_order on blocks(page_id, alive, parent_id, display_order, created_time, id)`); err != nil {
 		return err
 	}
@@ -311,6 +337,13 @@ func (s *Store) init(ctx context.Context) error {
 		if _, err := s.execContext(ctx, stmt); err != nil {
 			return err
 		}
+	}
+	if _, err := s.execContext(ctx, `update record_sources set
+		deleted_at = coalesce(deleted_at, synced_at),
+		deletion_source = coalesce(deletion_source, source),
+		deletion_reason = coalesce(deletion_reason, 'legacy-tombstone')
+		where alive = 0`); err != nil {
+		return err
 	}
 	if _, err := s.execContext(ctx, `insert or replace into meta(key, value) values('schema_version', ?)`, schemaVersion); err != nil {
 		return err
@@ -667,20 +700,7 @@ func (s *Store) RetireSourcePageBlocks(ctx context.Context, source, pageID strin
 		return 0, err
 	}
 	for _, id := range ids {
-		if _, err := s.execContext(ctx, `update record_sources set alive = 0, payload_json = null
-			where record_table = 'block' and record_id = ? and source = ?`, id, source); err != nil {
-			return 0, err
-		}
-		canonicalSource, _, exists, err := s.canonicalRecordSource(ctx, "block", id)
-		if err != nil {
-			return 0, err
-		}
-		if exists && canonicalSource == source {
-			if _, err := s.promoteFallbackRecord(ctx, "block", id); err != nil {
-				return 0, err
-			}
-		}
-		if err := s.refreshRecordAlive(ctx, "block", id); err != nil {
+		if err := s.retireRecordSource(ctx, "block", id, source, "parent-delete-event"); err != nil {
 			return 0, err
 		}
 	}
@@ -726,7 +746,7 @@ func (s *Store) RetireSourcePageBlocksNotSyncedAt(ctx context.Context, source, p
 		return 0, err
 	}
 	for _, id := range ids {
-		if err := s.retireRecordSource(ctx, "block", id, source); err != nil {
+		if err := s.retireRecordSource(ctx, "block", id, source, "complete-authoritative-enumeration"); err != nil {
 			return 0, err
 		}
 	}
@@ -742,7 +762,7 @@ func (s *Store) RetireSourcePageComments(ctx context.Context, source, pageID str
 		return 0, err
 	}
 	for _, id := range ids {
-		if err := s.retireRecordSource(ctx, "comment", id, source); err != nil {
+		if err := s.retireRecordSource(ctx, "comment", id, source, "parent-delete-event"); err != nil {
 			return 0, err
 		}
 	}
@@ -780,9 +800,15 @@ func (s *Store) sourceCommentIDsForPage(ctx context.Context, source, pageID stri
 	return ids, rows.Err()
 }
 
-func (s *Store) retireRecordSource(ctx context.Context, recordTable, recordID, source string) error {
-	if _, err := s.execContext(ctx, `update record_sources set alive = 0, payload_json = null
-		where record_table = ? and record_id = ? and source = ?`, recordTable, recordID, source); err != nil {
+func (s *Store) retireRecordSource(ctx context.Context, recordTable, recordID, source, reason string) error {
+	if _, err := s.execContext(ctx, `update record_sources set
+		alive = 0,
+		payload_json = null,
+		deleted_at = ?,
+		deletion_source = ?,
+		deletion_reason = ?
+		where record_table = ? and record_id = ? and source = ?`,
+		NowMS(), source, reason, recordTable, recordID, source); err != nil {
 		return err
 	}
 	canonicalSource, _, exists, err := s.canonicalRecordSource(ctx, recordTable, recordID)
@@ -804,13 +830,27 @@ func (s *Store) retireRecordSource(ctx context.Context, recordTable, recordID, s
 }
 
 func (s *Store) upsertRecordSource(ctx context.Context, recordTable, recordID, source string, syncedAt int64, alive bool, payload string) error {
-	_, err := s.execContext(ctx, `insert into record_sources(record_table, record_id, source, synced_at, alive, payload_json)
-		values (?, ?, ?, ?, ?, nullif(?, ''))
+	var deletedAt any
+	var deletionSource any
+	var deletionReason any
+	if !alive {
+		deletedAt = syncedAt
+		deletionSource = source
+		deletionReason = "explicit-source-delete"
+	}
+	_, err := s.execContext(ctx, `insert into record_sources(
+		record_table, record_id, source, synced_at, alive, payload_json,
+		deleted_at, deletion_source, deletion_reason)
+		values (?, ?, ?, ?, ?, nullif(?, ''), ?, ?, ?)
 		on conflict(record_table, record_id, source) do update set
 			synced_at = excluded.synced_at,
 			alive = excluded.alive,
-			payload_json = excluded.payload_json`,
-		recordTable, recordID, source, syncedAt, BoolInt(alive), payload)
+			payload_json = excluded.payload_json,
+			deleted_at = excluded.deleted_at,
+			deletion_source = excluded.deletion_source,
+			deletion_reason = excluded.deletion_reason`,
+		recordTable, recordID, source, syncedAt, BoolInt(alive), payload,
+		deletedAt, deletionSource, deletionReason)
 	return err
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -35,6 +35,143 @@ func TestStoreUpsertsAndSearchesPage(t *testing.T) {
 	}
 }
 
+func TestStoreRecordsAndClearsExplicitTombstoneMetadata(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	const deletedAt = int64(12345)
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Page", Alive: true, Source: "api", SyncedAt: deletedAt - 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Page", Alive: false, Source: "api", SyncedAt: deletedAt}); err != nil {
+		t.Fatal(err)
+	}
+	var gotDeletedAt int64
+	var source, reason string
+	if err := st.DB().QueryRowContext(ctx, `select deleted_at, deletion_source, deletion_reason
+		from record_sources where record_table = 'page' and record_id = 'page1' and source = 'api'`).Scan(
+		&gotDeletedAt, &source, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if gotDeletedAt != deletedAt || source != "api" || reason != "explicit-source-delete" {
+		t.Fatalf("tombstone metadata = %d %q %q", gotDeletedAt, source, reason)
+	}
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Restored", Alive: true, Source: "api", SyncedAt: deletedAt + 1}); err != nil {
+		t.Fatal(err)
+	}
+	var tombstoneFields int
+	if err := st.DB().QueryRowContext(ctx, `select
+		(deleted_at is not null) + (deletion_source is not null) + (deletion_reason is not null)
+		from record_sources where record_table = 'page' and record_id = 'page1' and source = 'api'`).Scan(&tombstoneFields); err != nil {
+		t.Fatal(err)
+	}
+	if tombstoneFields != 0 {
+		t.Fatalf("restored source retained %d tombstone fields", tombstoneFields)
+	}
+}
+
+func TestStoreRecordsAuthoritativeEnumerationTombstoneReason(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Page", Alive: true, Source: "api", SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{ID: "block1", PageID: "page1", ParentID: "page1", Type: "text", Alive: true, Source: "api", SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	retired, err := st.RetireSourcePageBlocksNotSyncedAt(ctx, "api", "page1", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retired != 1 {
+		t.Fatalf("retired blocks = %d", retired)
+	}
+	var source, reason string
+	if err := st.DB().QueryRowContext(ctx, `select deletion_source, deletion_reason
+		from record_sources where record_table = 'block' and record_id = 'block1' and source = 'api'`).Scan(&source, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if source != "api" || reason != "complete-authoritative-enumeration" {
+		t.Fatalf("tombstone metadata = %q %q", source, reason)
+	}
+}
+
+func TestStoreRecordsParentDeleteTombstoneReason(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Page", Alive: true, Source: "api", SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, Block{ID: "block1", PageID: "page1", ParentID: "page1", Type: "text", Alive: true, Source: "api", SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertComment(ctx, Comment{ID: "comment1", PageID: "page1", Text: "Comment", Alive: true, Source: "api", SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if retired, err := st.RetireSourcePageBlocks(ctx, "api", "page1"); err != nil || retired != 1 {
+		t.Fatalf("retired blocks=%d err=%v", retired, err)
+	}
+	if retired, err := st.RetireSourcePageComments(ctx, "api", "page1"); err != nil || retired != 1 {
+		t.Fatalf("retired comments=%d err=%v", retired, err)
+	}
+	for recordTable, recordID := range map[string]string{"block": "block1", "comment": "comment1"} {
+		var reason string
+		if err := st.DB().QueryRowContext(ctx, `select deletion_reason from record_sources
+			where record_table = ? and record_id = ? and source = 'api'`, recordTable, recordID).Scan(&reason); err != nil {
+			t.Fatal(err)
+		}
+		if reason != "parent-delete-event" {
+			t.Fatalf("%s deletion reason = %q", recordTable, reason)
+		}
+	}
+}
+
+func TestStoreMigratesLegacyTombstoneMetadata(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "notcrawl.db")
+	st, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, Page{ID: "page1", Title: "Page", Alive: false, Source: "api", SyncedAt: 123}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `update record_sources set deleted_at = null, deletion_source = null, deletion_reason = null`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `update meta set value = 3 where key = 'schema_version'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	st, err = Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	var deletedAt int64
+	var source, reason string
+	if err := st.DB().QueryRowContext(ctx, `select deleted_at, deletion_source, deletion_reason from record_sources
+		where record_table = 'page' and record_id = 'page1' and source = 'api'`).Scan(&deletedAt, &source, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if deletedAt != 123 || source != "api" || reason != "legacy-tombstone" {
+		t.Fatalf("migrated tombstone = %d %q %q", deletedAt, source, reason)
+	}
+}
+
 func TestStoreRestoresDesktopPayloadWhenAPISourceRetires(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(filepath.Join(t.TempDir(), "notcrawl.db"))


### PR DESCRIPTION
## Summary

- merge git-share snapshots by default without pruning local-only canonical rows or provenance, updating conflicts in place to preserve stable row identity
- preserve local tombstones against snapshot live state while applying explicit incoming tombstones
- add explicit `--restore` exact replacement plus optional local-only `record_revisions` retention
- record tombstone time, source, and reason for explicit deletes, authoritative enumeration, and parent delete events
- preserve mixed-source canonical selection and fallback payload promotion during merges

No `VISION.md` exists in this repository, so there was no repository vision file to update.

## Proof

Focused retention tests:

```text
go test -count=1 ./internal/store ./internal/share ./cmd/notcrawl
ok github.com/openclaw/notcrawl/internal/store
ok github.com/openclaw/notcrawl/internal/share
ok github.com/openclaw/notcrawl/cmd/notcrawl
```

Full gate:

```text
GOWORK=off go mod verify
GOWORK=off go mod tidy
gofmt -l .
GOWORK=off go vet ./...
deadcode -test ./...
GOWORK=off go test -count=1 ./...
govulncheck ./...
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off go build ./cmd/notcrawl
goreleaser check
goreleaser check --config .goreleaser-release.yml
goreleaser release --snapshot --clean --skip=publish
goreleaser release --snapshot --clean --skip=publish --config .goreleaser-release.yml
```

Observed: module cache verified; tidy and formatting clean; vet and deadcode clean; all packages passed; no vulnerabilities found; native and Windows CLI builds passed; both GoReleaser snapshot builds succeeded.

Real-binary fixture proof used the same committed local git snapshot and byte-identical destination databases:

```text
old subscribe: shared | Remote live | alive=1
new subscribe --retain-revisions: mode=merge revisions=1
  local-only | Local only | alive=1
  shared | Local deleted | alive=0
  tombstone: deleted_at=101 source=test reason=legacy-tombstone
  revision: spaces | snapshot-merge | retained Local space
new subscribe --restore --retain-revisions: mode=restore revisions=5
  shared | Remote live | alive=1
  local-only absent; tombstone fields empty
```

Separate CLI processes reopened and queried every database. `subscribe --help` exposed both retention flags. Source-blind behavior contract: 4 pass, 0 fail, 0 blocked. AutoReview local and branch modes: no accepted/actionable findings.
