### PR TITLE
build(release): notarize macOS binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Test
         run: go test -count=1 ./...
 
+      - name: Test macOS release scripts
+        run: ./scripts/test-notcrawl-macos-release.sh
+
       - name: Build CLI
         run: go build -ldflags "-X main.version=ci" -o bin/notcrawl ./cmd/notcrawl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.4 - Unreleased
 
+### Tooling
+
+- Notarize both official macOS binaries and require Apple notarization verification before release publication.
+
 ## 0.5.3 - 2026-07-17
 
 ### Highlights

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 BINARY ?= bin/notcrawl
 
-.PHONY: build test run fmt release-notes release-snapshot release-check release-artifacts release-macos verify-release-macos
+.PHONY: build test test-release run fmt release-notes release-snapshot release-check release-artifacts release-macos verify-release-macos
 
 build:
 	go build -o $(BINARY) ./cmd/notcrawl
 
 test:
 	go test ./...
+
+test-release:
+	./scripts/test-notcrawl-macos-release.sh
 
 run:
 	go run ./cmd/notcrawl $(ARGS)

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -3,11 +3,12 @@
 `notcrawl` ships through GitHub Releases, Homebrew tap updates, and optional
 Cloudsmith APT/RPM repositories.
 
-Official macOS archives are signed with identifier `org.openclaw.notcrawl` by
-the OpenClaw Foundation Apple Developer Team `FWJYW4S8P8`. Ordinary builds and
-GoReleaser snapshots do not need signing credentials. The official publish path
-is local to an authorized maintainer Mac and fails closed unless both signed
-architecture archives pass verification.
+Official macOS archives are signed with hardened runtime and identifier
+`org.openclaw.notcrawl`, then notarized by the OpenClaw Foundation Apple
+Developer Team `FWJYW4S8P8`. Ordinary builds and GoReleaser snapshots do not
+need signing credentials. The official publish path is local to an authorized
+maintainer Mac and fails closed unless both architecture archives pass signing
+and notarization verification.
 
 ## Local Checks
 
@@ -58,28 +59,33 @@ make release-artifacts TAG=v0.1.0
 ```
 
 This builds Linux archives and packages without credentials, then uses
-`release-mac-app codesign-run` to build the two signed macOS archives. The step
-requires Rosetta so both architectures can execute. It rejects a dirty or
-mismatched checkout, an invalid tag signature, a missing managed identity, the
-wrong Team ID or identifier, stale build provenance, incomplete archive
-contents, and checksum/asset-set mismatches. Private keychain and credential
-routing belongs in the ignored `.mac-release.env` or another approved runtime
-environment.
+`release-mac-app codesign-run` to build, sign, and notarize the two thin macOS
+archives. The step requires Rosetta so both architectures can execute. It
+rejects a dirty or mismatched checkout, an invalid tag signature, a missing
+managed identity or notarization profile, the wrong Team ID or identifier, a
+rejected notarization submission, stale build provenance, incomplete archive
+contents, and checksum/asset-set mismatches. Set
+`NOTARYTOOL_KEYCHAIN_PROFILE` to an approved login-keychain profile at runtime;
+never place notarization credentials in the repository. Private signing
+keychain routing belongs in the ignored `.mac-release.env` or another approved
+runtime environment.
 
 After inspecting the exact 11-file manifest in `dist/release-assets/`, push
 `main` and the tag, attach those files to the Release Drafter draft, verify its
 notes contain the changelog, then publish it locally. The local preparation
 step is the pre-publication gate: it verifies the exact manifest, checksums,
-binary provenance, and both Developer ID signatures before any upload. CI never
-imports the Developer ID private key and never publishes release assets.
+binary provenance, both Developer ID signatures, hardened runtime, and Apple
+notarization tickets before any upload. CI never imports the Developer ID
+private key or notarization credentials and never publishes release assets.
 
 The read-only `Release Validation` workflow runs after publication using
 verifier code from the trusted default branch. It checks the exact asset
 manifest and checksums, tests the tagged source, verifies every Linux
 archive/package binary embeds the tag commit, and verifies each macOS binary
 natively against the Apple trust chain, Team ID, identifier, version,
-architecture, and embedded tag commit. The Homebrew workflow then updates the
-tap; Cloudsmith publication remains an explicit follow-up.
+architecture, embedded tag commit, and notarization ticket. The Homebrew
+workflow then updates the tap; Cloudsmith publication remains an explicit
+follow-up.
 
 ## Required Secrets
 

--- a/scripts/notarize-notcrawl-macos.sh
+++ b/scripts/notarize-notcrawl-macos.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINARY=${1:-}
+
+if [[ "$#" -ne 1 || -z "$BINARY" ]]; then
+  echo "usage: $0 path-to-signed-notcrawl-binary" >&2
+  exit 2
+fi
+[[ "$(uname -s)" == Darwin ]] || {
+  echo "notcrawl notarization must run on macOS" >&2
+  exit 1
+}
+[[ -f "$BINARY" ]] || {
+  echo "notcrawl binary does not exist: $BINARY" >&2
+  exit 1
+}
+[[ -n "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]] || {
+  echo "NOTARYTOOL_KEYCHAIN_PROFILE is required for notcrawl release notarization" >&2
+  exit 1
+}
+
+for tool in codesign ditto mktemp plutil xcrun; do
+  command -v "$tool" >/dev/null || {
+    echo "missing required tool: $tool" >&2
+    exit 1
+  }
+done
+
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/notcrawl-notary.XXXXXX")
+trap 'rm -rf "$WORK_DIR"' EXIT
+SUBMISSION="$WORK_DIR/$(basename "$BINARY").zip"
+
+ditto -c -k --sequesterRsrc --keepParent "$BINARY" "$SUBMISSION"
+if ! NOTARY_RESULT=$(xcrun notarytool submit "$SUBMISSION" \
+  --keychain-profile "$NOTARYTOOL_KEYCHAIN_PROFILE" \
+  --no-s3-acceleration \
+  --wait \
+  --output-format json); then
+  echo "notcrawl notarization submission failed: $BINARY" >&2
+  exit 1
+fi
+
+NOTARY_STATUS=$(plutil -extract status raw -o - - <<<"$NOTARY_RESULT")
+NOTARY_ID=$(plutil -extract id raw -o - - <<<"$NOTARY_RESULT")
+[[ "$NOTARY_STATUS" == Accepted ]] || {
+  echo "notcrawl notarization status is ${NOTARY_STATUS:-missing}, expected Accepted" >&2
+  exit 1
+}
+[[ "$NOTARY_ID" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$ ]] || {
+  echo "notcrawl notarization response has an invalid submission id" >&2
+  exit 1
+}
+
+codesign --verify --strict --check-notarization -R=notarized --verbose=2 "$BINARY"
+printf 'notarized %s submission=%s\n' "$BINARY" "$NOTARY_ID"

--- a/scripts/package-notcrawl-macos-release.sh
+++ b/scripts/package-notcrawl-macos-release.sh
@@ -31,6 +31,10 @@ usage() {
   echo "notcrawl releases require $EXPECTED_AUTHORITY" >&2
   exit 1
 }
+[[ -n "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]] || {
+  echo "NOTARYTOOL_KEYCHAIN_PROFILE is required for notcrawl release notarization" >&2
+  exit 1
+}
 
 for tool in arch codesign git go lipo shasum tar; do
   command -v "$tool" >/dev/null || {
@@ -101,6 +105,8 @@ for arch in arm64 amd64; do
   else
     [[ "$("$binary" --version)" == "$VERSION" ]]
   fi
+
+  "$ROOT/scripts/notarize-notcrawl-macos.sh" "$binary"
 
   for file in README.md LICENSE SPEC.md config.example.toml; do
     cp "$ROOT/$file" "$stage/$file"

--- a/scripts/test-notcrawl-macos-release.sh
+++ b/scripts/test-notcrawl-macos-release.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+EXPECTED_AUTHORITY='Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)'
+
+fail() {
+  echo "macOS release script test failed: $*" >&2
+  exit 1
+}
+
+for script in notarize-notcrawl-macos.sh package-notcrawl-macos-release.sh verify-notcrawl-macos-release.sh; do
+  bash -n "$ROOT/scripts/$script"
+done
+# shellcheck disable=SC2016
+grep -F '"$ROOT/scripts/notarize-notcrawl-macos.sh" "$binary"' \
+  "$ROOT/scripts/package-notcrawl-macos-release.sh" >/dev/null
+grep -F 'codesign --verify --strict --check-notarization -R=notarized' \
+  "$ROOT/scripts/verify-notcrawl-macos-release.sh" >/dev/null
+
+WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/notcrawl-notary-test.XXXXXX")
+trap 'rm -rf "$WORK_DIR"' EXIT
+FAKE_BIN="$WORK_DIR/bin"
+mkdir -p "$FAKE_BIN"
+export MOCK_CODESIGN_LOG="$WORK_DIR/codesign.log"
+export MOCK_XCRUN_LOG="$WORK_DIR/xcrun.log"
+
+cat >"$FAKE_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) echo Darwin ;;
+  -m) echo arm64 ;;
+  *) echo Darwin ;;
+esac
+EOF
+
+cat >"$FAKE_BIN/ditto" <<'EOF'
+#!/usr/bin/env bash
+[[ "$#" -eq 6 && "$1" == -c && "$2" == -k && "$3" == --sequesterRsrc && "$4" == --keepParent ]]
+[[ -f "$5" && "$6" == *.zip ]]
+cp "$5" "$6"
+EOF
+
+cat >"$FAKE_BIN/xcrun" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${MOCK_XCRUN_LOG:?}"
+[[ "${1:-}" == notarytool && "${2:-}" == submit && -f "${3:-}" ]]
+shift 3
+profile=
+no_s3=0
+wait_for_result=0
+json_output=0
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --keychain-profile) profile=${2:-}; shift 2 ;;
+    --no-s3-acceleration) no_s3=1; shift ;;
+    --wait) wait_for_result=1; shift ;;
+    --output-format) [[ "${2:-}" == json ]] && json_output=1; shift 2 ;;
+    *) exit 2 ;;
+  esac
+done
+[[ "$profile" == test-notary-profile && "$no_s3" == 1 && "$wait_for_result" == 1 && "$json_output" == 1 ]]
+[[ "${MOCK_NOTARY_EXIT:-0}" == 0 ]] || exit 1
+printf '{"id":"%s","status":"%s"}\n' \
+  "${MOCK_NOTARY_ID:-01234567-89ab-cdef-0123-456789abcdef}" \
+  "${MOCK_NOTARY_STATUS:-Accepted}"
+EOF
+
+cat >"$FAKE_BIN/plutil" <<'EOF'
+#!/usr/bin/env bash
+[[ "$#" -eq 6 && "$1" == -extract && "$3" == raw && "$4" == -o && "$5" == - && "$6" == - ]]
+cat >/dev/null
+case "$2" in
+  status) printf '%s\n' "${MOCK_NOTARY_STATUS:-Accepted}" ;;
+  id) printf '%s\n' "${MOCK_NOTARY_ID:-01234567-89ab-cdef-0123-456789abcdef}" ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"$FAKE_BIN/codesign" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${MOCK_CODESIGN_LOG:?}"
+if [[ " $* " == *' --check-notarization '* && "${MOCK_NOTARY_TICKET:-accepted}" != accepted ]]; then
+  exit 1
+fi
+EOF
+
+chmod +x "$FAKE_BIN"/*
+BINARY="$WORK_DIR/notcrawl"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$BINARY"
+chmod +x "$BINARY"
+TEST_PATH="$FAKE_BIN:/usr/bin:/bin"
+
+if PATH="$TEST_PATH" "$ROOT/scripts/notarize-notcrawl-macos.sh" "$BINARY" \
+  >"$WORK_DIR/missing-profile.out" 2>"$WORK_DIR/missing-profile.err"; then
+  fail "notarization accepted a missing keychain profile"
+fi
+grep -F 'NOTARYTOOL_KEYCHAIN_PROFILE is required' "$WORK_DIR/missing-profile.err" >/dev/null
+
+if PATH="$TEST_PATH" CODESIGN_IDENTITY="$EXPECTED_AUTHORITY" \
+  "$ROOT/scripts/package-notcrawl-macos-release.sh" v9.9.9 "$WORK_DIR/package" \
+  >"$WORK_DIR/package-missing-profile.out" 2>"$WORK_DIR/package-missing-profile.err"; then
+  fail "release packaging accepted a missing keychain profile"
+fi
+grep -F 'NOTARYTOOL_KEYCHAIN_PROFILE is required' "$WORK_DIR/package-missing-profile.err" >/dev/null
+
+PATH="$TEST_PATH" NOTARYTOOL_KEYCHAIN_PROFILE=test-notary-profile \
+  "$ROOT/scripts/notarize-notcrawl-macos.sh" "$BINARY" >"$WORK_DIR/accepted.out"
+grep -F 'submission=01234567-89ab-cdef-0123-456789abcdef' "$WORK_DIR/accepted.out" >/dev/null
+grep -F -- '--keychain-profile test-notary-profile' "$MOCK_XCRUN_LOG" >/dev/null
+grep -F -- '--wait --output-format json' "$MOCK_XCRUN_LOG" >/dev/null
+grep -F -- '--check-notarization -R=notarized' "$MOCK_CODESIGN_LOG" >/dev/null
+
+if PATH="$TEST_PATH" NOTARYTOOL_KEYCHAIN_PROFILE=test-notary-profile MOCK_NOTARY_STATUS=Invalid \
+  "$ROOT/scripts/notarize-notcrawl-macos.sh" "$BINARY" >/dev/null 2>"$WORK_DIR/invalid-status.err"; then
+  fail "notarization accepted an invalid service status"
+fi
+grep -F 'status is Invalid, expected Accepted' "$WORK_DIR/invalid-status.err" >/dev/null
+
+if PATH="$TEST_PATH" NOTARYTOOL_KEYCHAIN_PROFILE=test-notary-profile MOCK_NOTARY_TICKET=rejected \
+  "$ROOT/scripts/notarize-notcrawl-macos.sh" "$BINARY" >/dev/null 2>"$WORK_DIR/rejected-ticket.err"; then
+  fail "notarization accepted a missing local ticket assessment"
+fi
+
+echo "macOS release script tests passed"

--- a/scripts/verify-notcrawl-macos-release.sh
+++ b/scripts/verify-notcrawl-macos-release.sh
@@ -85,6 +85,7 @@ for archive in "$@"; do
   [[ -x "$binary" ]]
 
   codesign --verify --strict -R="$REQUIREMENT" --verbose=2 "$binary"
+  codesign --verify --strict --check-notarization -R=notarized --verbose=2 "$binary"
   signature=$(codesign -dvvv "$binary" 2>&1)
   grep -Fx "Identifier=$IDENTIFIER" <<<"$signature" >/dev/null
   grep -Fx "TeamIdentifier=$EXPECTED_TEAM_ID" <<<"$signature" >/dev/null


### PR DESCRIPTION
## Summary

- fail closed unless `NOTARYTOOL_KEYCHAIN_PROFILE` names an available runtime Keychain profile
- notarize both shipped thin macOS binaries before archive creation and require an Accepted response
- verify Apple notarization assessment during packaging and release verification
- add credential-free failure/acceptance regressions to hosted CI and document the local release contract

## Proof

Credential-free release regressions:

```text
shellcheck scripts/notarize-notcrawl-macos.sh scripts/package-notcrawl-macos-release.sh scripts/verify-notcrawl-macos-release.sh scripts/test-notcrawl-macos-release.sh
actionlint .github/workflows/ci.yml
./scripts/test-notcrawl-macos-release.sh
macOS release script tests passed
```

Covered: missing profile rejection in both helper and package entrypoint, exact profile forwarding, blocking `--wait` JSON submission, Accepted-status enforcement, and failed local notarization-assessment rejection.

Real Apple notarization proof used the approved login-keychain profile on fresh scratch builds:

```text
CGO_ENABLED=0 GOOS=darwin GOARCH=<arm64|amd64> go build ...
codesign --force --options runtime --timestamp --identifier org.openclaw.notcrawl --sign <Foundation Developer ID> <binary>
NOTARYTOOL_KEYCHAIN_PROFILE=<approved-profile> ./scripts/notarize-notcrawl-macos.sh <binary>
codesign --verify --strict --check-notarization -R=notarized --verbose=2 <binary>
codesign -d -r- <binary>
lipo -archs <binary>
```

Observed for both arm64 and x86_64: Apple status Accepted; post-submission notarization assessment passed; hardened-runtime Developer ID signature satisfied `org.openclaw.notcrawl`; designated requirement remained canonical; exactly one expected architecture slice; real binary returned `0.5.4-notary-proof` (x86_64 via Rosetta).

Full repository gate:

```text
GOWORK=off go mod verify
GOWORK=off go mod tidy
gofmt -l .
GOWORK=off go vet ./...
deadcode -test ./...
GOWORK=off go test -count=1 ./...
govulncheck ./...
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GOWORK=off go build ./cmd/notcrawl
goreleaser check
goreleaser check --config .goreleaser-release.yml
goreleaser release --snapshot --clean --skip=publish
goreleaser release --snapshot --clean --skip=publish --config .goreleaser-release.yml
```

Observed: tidy/format/vet/deadcode clean; all packages passed; no vulnerabilities; native and Windows builds passed; both GoReleaser snapshot configurations succeeded. AutoReview local and branch modes: no accepted/actionable findings.
