### PR TITLE
chore: prepare v0.5.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.5 - Unreleased
+## 0.5.5 - 2026-07-26
 
 ### Dependencies
 


### PR DESCRIPTION
## Summary

Stamp the existing 0.5.5 changelog section with the release date `2026-07-26` so the shared release workflow can freeze its notes and publish v0.5.5.

## Verification

- structured Codex autoreview: clean, no accepted or actionable findings
