### PR TITLE
fix: verify unified release archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.5.6 - Unreleased
+
+### Tooling
+
+- Accept the shared release pipeline's normalized archive member paths in local release verification.
 
 ## 0.5.5 - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.5.5 - 2026-07-26
 
 ### Dependencies

--- a/scripts/verify-notcrawl-macos-release.sh
+++ b/scripts/verify-notcrawl-macos-release.sh
@@ -50,7 +50,7 @@ for archive in "$@"; do
       ;;
   esac
 
-  members=$(tar -tzf "$archive" | LC_ALL=C sort)
+  members=$(tar -tzf "$archive" | sed 's#^\./##' | sed '/^$/d' | LC_ALL=C sort)
   [[ "$members" == "$EXPECTED_MEMBERS" ]] || {
     echo "unexpected archive contents in $(basename "$archive")" >&2
     printf '%s\n' "$members" >&2

--- a/scripts/verify-notcrawl-release.sh
+++ b/scripts/verify-notcrawl-release.sh
@@ -103,13 +103,13 @@ EXPECTED_LINUX_MEMBERS=$'CHANGELOG.md\nLICENSE\nREADME.md\nSPEC.md\nconfig.examp
 for arch in amd64 arm64; do
   archive="$ASSET_DIR/notcrawl_${VERSION}_linux_${arch}.tar.gz"
   stage="$WORK_DIR/archive-$arch"
-  members=$(tar -tzf "$archive" | LC_ALL=C sort)
+  members=$(tar -tzf "$archive" | sed 's#^\./##' | sed '/^$/d' | LC_ALL=C sort)
   [[ "$members" == "$EXPECTED_LINUX_MEMBERS" ]] || {
     echo "unexpected archive contents in $(basename "$archive")" >&2
     exit 1
   }
   mkdir -p "$stage"
-  tar -xzf "$archive" -C "$stage" notcrawl
+  tar -xzf "$archive" -C "$stage"
   verify_go_provenance "$stage/notcrawl" "$arch"
 done
 


### PR DESCRIPTION
## Summary

- roll the changelog forward to `0.5.6 - Unreleased` after publishing v0.5.5
- normalize the shared pipeline's leading `./` archive member paths in local release verification
- extract the already inventory-validated Linux archive as a whole so the verifier accepts the shared archive layout

The shared release workflow pushed this branch but could not open its closeout PR because this repository does not allow GitHub Actions to create pull requests. This PR completes that closeout manually.

## Verification

- `make verify-release TAG=v0.5.5 ASSET_DIR=/tmp/notcrawl-v055.9OF3Cp`
  - all twelve aggregate checksum entries passed
  - both Linux archives and all four nFPM packages passed provenance checks
  - both macOS archives passed Developer ID, stable identifier, architecture, version, and notarization checks
- structured Codex autoreview: clean, no accepted or actionable findings
