### PR TITLE
chore: prepare 0.5.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.6 - Unreleased
+## 0.5.6 - 2026-08-01
 
 ### Dependencies
 


### PR DESCRIPTION
## Summary

- stamp the `0.5.6` changelog section with the 2026-08-01 release date
- freeze the release notes required by the canonical unified workflow

## Verification

- `make check`
- release-script tests passed
- both GoReleaser snapshot configurations built successfully
- autoreview clean with no accepted/actionable findings
