### PR TITLE
ci: adopt workflow-owned release tags

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,2 +1,0 @@
-steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA6rFpd7CodTF6fy60LZTriTeiGAJ7haIBWD4hrdxmDB steipete@gmail.com
-steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9 steipete@gmail.com

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -26,9 +26,8 @@ jobs:
       homebrew-formula: notcrawl
       archive-files: '["CHANGELOG.md","LICENSE","README.md","SPEC.md","config.example.toml"]'
       checksum-filename: sha256sums.txt
-      nfpm: enabled
+      nfpm: auto
       stable-identifier: org.openclaw.notcrawl
-      require-signed-tag: true
       darwin-universal: disabled
       ci-check-events: '["push","pull_request"]'
     secrets:
@@ -37,4 +36,4 @@ jobs:
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
       ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY_P8 }}
-      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.6 - 2026-08-01
+## 0.5.6 - 2026-08-02
 
 ### Dependencies
 
@@ -8,6 +8,7 @@
 
 ### Tooling
 
+- Let the unified release workflow create the immutable release tag and consume organization-managed signing, notarization, and Homebrew credentials without local secret access.
 - Accept the shared release pipeline's normalized archive member paths in local release verification.
 
 ## 0.5.5 - 2026-07-26

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -33,19 +33,17 @@ refuse local publication and print the official workflow command.
 ## Official Release
 
 Stamp the changelog section with the release date, merge it to protected
-`main`, and create and push an annotated SSH-signed tag. The signer must appear
-in `.github/release-allowed-signers`.
+`main`, then dispatch the unified workflow:
 
 ```bash
-git tag -s v0.5.5 -m "notcrawl v0.5.5"
-git push origin v0.5.5
 gh workflow run release-unified.yml --repo openclaw/notcrawl -f version=0.5.5
 ```
 
-The workflow freezes the protected source revision, verifies independent CI,
-builds the GoReleaser matrix and nFPM packages, signs and notarizes both macOS
-architectures, verifies the complete draft independently on Intel and Apple
-Silicon, publishes the GitHub release, and verifies the Homebrew handoff.
+The workflow freezes the protected source revision, creates the immutable
+annotated tag, verifies independent CI, builds the GoReleaser matrix and nFPM
+packages, signs and notarizes both macOS architectures, verifies the complete
+draft independently on Intel and Apple Silicon, publishes the GitHub release,
+and verifies the Homebrew handoff.
 
 The published `v0.5.4` contract contained six Linux assets: two archives, two
 Debian packages, and two RPM packages. The unified workflow preserves all six
@@ -89,11 +87,14 @@ make verify-release TAG=v0.5.5
 archives in `dist/`. These targets are read-only diagnostics; they never upload
 or alter a release.
 
-## Required Secrets
+## Organization Secrets
+
+The workflow receives release credentials from GitHub organization secrets;
+release operators never load them locally:
 
 - `MACOS_SIGNING_P12`
 - `MACOS_SIGNING_P12_PASSWORD`
 - `ASC_KEY_ID`
 - `ASC_ISSUER_ID`
 - `ASC_PRIVATE_KEY_P8`
-- `HOMEBREW_TAP_GITHUB_TOKEN`, mapped to the shared workflow's `TAP_TOKEN`
+- `HOMEBREW_TAP_TOKEN`, mapped to the shared workflow's `TAP_TOKEN`


### PR DESCRIPTION
## Summary

- let the shared `release-go-cli.yml@v1` workflow create the immutable release tag
- use the graincrawl-style organization Homebrew secret and `nfpm: auto`
- remove the obsolete local SSH signer allowlist and signed-tag instructions
- retain notcrawl's established archive members, checksum name, stable identifier, and native Darwin asset contract
- date and document the pending 0.5.6 release

The `@v1` audit found one reusable release variant, `release-go-cli.yml`; it matches this Go CLI and its GoReleaser/nFPM packaging. `openclaw/homebrew-tap` already contains `Formula/notcrawl.rb`, so Homebrew handoff remains enabled.

## Verification

- `actionlint .github/workflows/release-unified.yml`
- `make check`
- release-script tests passed
- both GoReleaser snapshot configurations built successfully
- autoreview clean with no accepted/actionable findings
