### PR TITLE
fix(ci): use legacy Homebrew tap secret

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -36,4 +36,4 @@ jobs:
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
       ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY_P8 }}
-      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -97,4 +97,4 @@ release operators never load them locally:
 - `ASC_KEY_ID`
 - `ASC_ISSUER_ID`
 - `ASC_PRIVATE_KEY_P8`
-- `HOMEBREW_TAP_TOKEN`, mapped to the shared workflow's `TAP_TOKEN`
+- `HOMEBREW_TAP_GITHUB_TOKEN`, mapped to the shared workflow's `TAP_TOKEN`


### PR DESCRIPTION
## Summary

- map the reusable workflow's `TAP_TOKEN` from notcrawl's existing `HOMEBREW_TAP_GITHUB_TOKEN` repository secret
- keep the release documentation aligned with the deployed legacy secret name

This repairs the v0.5.6 Homebrew handoff failure, which reported `TAP_TOKEN_PRESENT: false` after the release itself was successfully published.

## Verification

- `actionlint .github/workflows/release-unified.yml`
- autoreview clean with no accepted/actionable findings
