### PR TITLE
chore: open 0.5.7 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.5.7 - Unreleased
+
 ## 0.5.6 - 2026-08-02
 
 ### Dependencies


### PR DESCRIPTION
## Summary

- open the `0.5.7 - Unreleased` changelog section after the verified v0.5.6 release and Homebrew handoff

## Verification

- release `v0.5.6` is published with 12 verified assets
- `openclaw/tap/notcrawl` resolves stable version 0.5.6
- `brew audit --strict openclaw/tap/notcrawl` passes
- autoreview clean with no accepted/actionable findings
