### PR TITLE
fix(api): use 60s default HTTP client when none is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.7 - Unreleased
 
+### Fixed
+
+- Use a 60-second default HTTP client for Notion API sync when no client is injected, so stalled API peers cannot hang the CLI forever. Thanks @SebTardif.
+
 ## 0.5.6 - 2026-08-02
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.5.7 - Unreleased
-
-### Fixed
-
-- Use a 60-second default HTTP client for Notion API sync when no client is injected, so stalled API peers cannot hang the CLI forever. Thanks @SebTardif.
-
 ## 0.5.6 - 2026-08-02
 
 ### Dependencies

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -28,6 +28,14 @@ func defaultHTTPClient() *http.Client {
 	return &http.Client{Timeout: defaultHTTPTimeout}
 }
 
+// httpClientOrDefault returns the injected client, or a 60s default when nil.
+func httpClientOrDefault(c *http.Client) *http.Client {
+	if c == nil {
+		return defaultHTTPClient()
+	}
+	return c
+}
+
 type Client struct {
 	BaseURL string
 	Version string
@@ -55,9 +63,7 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 	if c.Version == "" {
 		c.Version = "2026-03-11"
 	}
-	if c.HTTP == nil {
-		c.HTTP = defaultHTTPClient()
-	}
+	c.HTTP = httpClientOrDefault(c.HTTP)
 	var s Summary
 	if err := st.DeferPageFTS(ctx, func() error {
 		users, err := c.listUsers(ctx)

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -20,6 +20,14 @@ const SourceName = "api"
 
 const maxAPIAttempts = 4
 
+// defaultHTTPTimeout bounds Notion API requests when Client.HTTP is nil.
+// Callers may inject a custom client (including Timeout 0 for tests).
+const defaultHTTPTimeout = 60 * time.Second
+
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultHTTPTimeout}
+}
+
 type Client struct {
 	BaseURL string
 	Version string
@@ -48,7 +56,7 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 		c.Version = "2026-03-11"
 	}
 	if c.HTTP == nil {
-		c.HTTP = http.DefaultClient
+		c.HTTP = defaultHTTPClient()
 	}
 	var s Summary
 	if err := st.DeferPageFTS(ctx, func() error {

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -992,3 +992,30 @@ func TestIngestCommentsRetriesCloudflareTimeout(t *testing.T) {
 		t.Fatalf("unexpected count/attempts: count=%d attempts=%d", count, attempts)
 	}
 }
+
+func TestDefaultHTTPClientBoundsOverallTimeout(t *testing.T) {
+	client := defaultHTTPClient()
+	if client.Timeout != defaultHTTPTimeout {
+		t.Fatalf("default HTTP timeout = %s, want %s", client.Timeout, defaultHTTPTimeout)
+	}
+	if client.Timeout <= 0 {
+		t.Fatalf("default HTTP timeout must be positive, got %s", client.Timeout)
+	}
+}
+
+func TestSyncUsesDefaultHTTPClientWhenHTTPNil(t *testing.T) {
+	// Exercise the nil-HTTP branch without performing a full sync: Sync
+	// returns early on missing token before Do, but still installs the client.
+	// We verify the helper used by that branch instead of hitting Notion.
+	c := Client{Token: "secret"}
+	if c.HTTP != nil {
+		t.Fatal("expected nil HTTP before Sync setup")
+	}
+	// Mirror Sync's nil guard
+	if c.HTTP == nil {
+		c.HTTP = defaultHTTPClient()
+	}
+	if c.HTTP.Timeout != defaultHTTPTimeout {
+		t.Fatalf("Sync default HTTP timeout = %s, want %s", c.HTTP.Timeout, defaultHTTPTimeout)
+	}
+}

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openclaw/notcrawl/internal/store"
 )
@@ -1004,18 +1005,40 @@ func TestDefaultHTTPClientBoundsOverallTimeout(t *testing.T) {
 }
 
 func TestSyncUsesDefaultHTTPClientWhenHTTPNil(t *testing.T) {
-	// Exercise the nil-HTTP branch without performing a full sync: Sync
-	// returns early on missing token before Do, but still installs the client.
-	// We verify the helper used by that branch instead of hitting Notion.
-	c := Client{Token: "secret"}
+	// Shared selector used by Sync on the nil-HTTP branch.
+	if got := httpClientOrDefault(nil); got.Timeout != defaultHTTPTimeout {
+		t.Fatalf("nil client timeout = %s, want %s", got.Timeout, defaultHTTPTimeout)
+	}
+	custom := &http.Client{Timeout: 5 * time.Second}
+	if got := httpClientOrDefault(custom); got != custom {
+		t.Fatal("injected client must be preserved")
+	}
+
+	// Call production Sync with HTTP left nil (value receiver installs default on the copy).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users":
+			_, _ = w.Write([]byte(`{"object":"list","results":[],"has_more":false}`))
+		case "/search":
+			_, _ = w.Write([]byte(`{"object":"list","results":[],"has_more":false}`))
+		default:
+			_, _ = w.Write([]byte(`{"object":"list","results":[],"has_more":false}`))
+		}
+	}))
+	defer server.Close()
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	c := Client{BaseURL: server.URL, Version: "2022-06-28", Token: "secret"} // HTTP nil
 	if c.HTTP != nil {
-		t.Fatal("expected nil HTTP before Sync setup")
+		t.Fatal("expected nil HTTP before Sync")
 	}
-	// Mirror Sync's nil guard
-	if c.HTTP == nil {
-		c.HTTP = defaultHTTPClient()
-	}
-	if c.HTTP.Timeout != defaultHTTPTimeout {
-		t.Fatalf("Sync default HTTP timeout = %s, want %s", c.HTTP.Timeout, defaultHTTPTimeout)
+	if _, err := c.Sync(context.Background(), st); err != nil {
+		t.Fatalf("Sync with nil HTTP: %v", err)
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

`notionapi.Client.Sync` falls back to `http.DefaultClient` when `HTTP` is nil. That client has no overall `Timeout`, so a stalled Notion TCP connection can hang the CLI forever when the caller context has no deadline (typical for CLI sync).

## Evidence

- Production path: `cmd/notcrawl` builds `notionapi.Client{...}` without `HTTP`, so every API sync hits the nil branch in `Sync`.
- Before: `c.HTTP = http.DefaultClient` (`Timeout == 0`).
- After: `c.HTTP = defaultHTTPClient()` with `Timeout: 60s`.
- Callers that inject their own client (including tests with `httptest`) are unchanged.

## Real behavior proof

**Environment:** Go 1.26, macOS; branch `fix/default-http-client-timeout`

**Setup:** none

**Command:**
```bash
# RED: defaultHTTPClient returns http.DefaultClient
go test ./internal/notionapi/ -count=1 -run 'TestDefaultHTTPClient|TestSyncUsesDefault'
# GREEN:
go test ./internal/notionapi/ -count=1 -run 'TestDefaultHTTPClient|TestSyncUsesDefault'
go test ./... -count=1
```

**Output:**
```
# RED
--- FAIL: TestDefaultHTTPClientBoundsOverallTimeout
    default HTTP timeout = 0s, want 1m0s
# GREEN
ok  github.com/openclaw/notcrawl/internal/notionapi
ok  ... (full suite)
```

**Why this proves it:** Unit tests assert the default client has a positive 60s timeout and is what Sync installs on the nil-HTTP branch. Full package suite remains green.

**Limits:** Does not hit live api.notion.com; bounds client construction and unit tests only.

## Test plan

- [x] Red/green on timeout assertions
- [x] Full `go test ./...`

## Review follow-up (Sync path + changelog)

Claw P2s:
1. Extracted `httpClientOrDefault` used by `Sync`; tests cover the helper and a real `Sync` call with `HTTP == nil` against httptest.
2. Removed release-owned Unreleased changelog entry.

**Evidence after fix (terminal):**

```console
$ go test ./internal/notionapi/ -count=1 -run 'SyncUsesDefault|DefaultHTTP' -v
--- PASS: TestDefaultHTTPClientBoundsOverallTimeout
--- PASS: TestSyncUsesDefaultHTTPClientWhenHTTPNil
PASS
ok  github.com/openclaw/notcrawl/internal/notionapi
```
