### PR TITLE
fix(api): bound default HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.7 - Unreleased
 
+### Fixed
+
+- Bound default Notion API requests to 60 seconds so a stalled peer cannot hang sync indefinitely. Thanks @SebTardif.
+
 ## 0.5.6 - 2026-08-02
 
 ### Dependencies

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -20,6 +20,21 @@ const SourceName = "api"
 
 const maxAPIAttempts = 4
 
+// defaultHTTPTimeout bounds Notion API requests when Client.HTTP is nil.
+// Callers may inject a custom client, including one with no overall timeout.
+const defaultHTTPTimeout = 60 * time.Second
+
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultHTTPTimeout}
+}
+
+func httpClientOrDefault(client *http.Client) *http.Client {
+	if client == nil {
+		return defaultHTTPClient()
+	}
+	return client
+}
+
 type Client struct {
 	BaseURL string
 	Version string
@@ -47,9 +62,7 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 	if c.Version == "" {
 		c.Version = "2026-03-11"
 	}
-	if c.HTTP == nil {
-		c.HTTP = http.DefaultClient
-	}
+	c.HTTP = httpClientOrDefault(c.HTTP)
 	var s Summary
 	if err := st.DeferPageFTS(ctx, func() error {
 		users, err := c.listUsers(ctx)

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openclaw/notcrawl/internal/store"
 )
@@ -990,5 +991,38 @@ func TestIngestCommentsRetriesCloudflareTimeout(t *testing.T) {
 	}
 	if count != 0 || attempts != 2 {
 		t.Fatalf("unexpected count/attempts: count=%d attempts=%d", count, attempts)
+	}
+}
+
+func TestDefaultHTTPClientBoundsOverallTimeout(t *testing.T) {
+	client := defaultHTTPClient()
+	if client.Timeout != defaultHTTPTimeout {
+		t.Fatalf("default HTTP timeout = %s, want %s", client.Timeout, defaultHTTPTimeout)
+	}
+}
+
+func TestHTTPClientOrDefaultPreservesInjectedClient(t *testing.T) {
+	custom := &http.Client{Timeout: 5 * time.Second}
+	if got := httpClientOrDefault(custom); got != custom {
+		t.Fatal("injected client must be preserved")
+	}
+}
+
+func TestSyncUsesDefaultHTTPClientWhenHTTPNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","results":[],"has_more":false}`))
+	}))
+	defer server.Close()
+
+	st, err := store.Open(filepath.Join(t.TempDir(), "notcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	client := Client{BaseURL: server.URL, Version: "2022-06-28", Token: "secret"}
+	if _, err := client.Sync(context.Background(), st); err != nil {
+		t.Fatalf("Sync with nil HTTP: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- give nil-client Notion API syncs a 60-second overall HTTP timeout
- preserve caller-injected HTTP clients unchanged
- add focused default/injection/production-Sync coverage
- credit @SebTardif for finding and implementing the original fix in #88

## Root cause

The CLI constructs `notionapi.Client` without an HTTP client. Since the API adapter was introduced, `Sync` has fallen back to `http.DefaultClient`, whose overall timeout is zero, so a peer that accepts a connection but never responds can hold the CLI indefinitely.

## Proof

- `make check` passed: dependency verification, govulncheck, format, vet/deadcode, all tests, macOS release-script tests, CLI smoke, GoReleaser validation, and both snapshot builds.
- Built CLI against a healthy local Notion-compatible endpoint: completed immediately with `api: users=0 pages=0 databases=0 database_rows=0 blocks=0 comments=0`.
- Built CLI against a controlled endpoint that accepted `/users` and never sent headers: exited nonzero after 61 seconds with `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`.
- Codex autoreview reported no accepted/actionable findings.

Supersedes #88 with its contributor credit preserved in the commit trailer.
