### PR TITLE
chore: prepare 0.5.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.7 - Unreleased
+## 0.5.7 - 2026-08-02
 
 ### Fixed
 


### PR DESCRIPTION
## Release

Close the 0.5.7 changelog section for the authorized patch release.

## Contents

- bound default Notion API requests to 60 seconds so stalled peers cannot hang sync indefinitely
- update modernc.org/sqlite to v1.56.0 with the SQLite 3.53.3 journal-rollback corruption fix
- update CrawlKit, indirect Go modules, validation tooling, and Release Drafter automation

## Proof

- non-parked issue and PR queue is zero
- `make check` passed after changelog closeout, including govulncheck, lint, all tests, macOS release-script tests, CLI smoke, release config validation, and both snapshot builds
- Codex autoreview reported no accepted/actionable findings
- live CLI proof for the timeout fix and updated SQLite driver is recorded on #91 and #92
