### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ See [`SPEC.md`](SPEC.md) for the data model and archive contracts. Maintainers c
 
 ## Development
 
-Go 1.26.5 or newer is required.
+Go 1.26.6 or newer is required.
 
 ```sh
 make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/notcrawl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.16.1


### PR DESCRIPTION
## Summary

- move the module Go floor and development requirement from 1.26.5 to 1.26.6
- clear GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218

## Proof

- `GOTOOLCHAIN=go1.26.6 go build ./...`
- `GOTOOLCHAIN=go1.26.6 go test ./...`
- `GOTOOLCHAIN=go1.26.6 GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` reported no vulnerabilities
- built and executed `cmd/notcrawl` with Go 1.26.6; `--version` reported dev
- autoreview clean with no accepted or actionable findings
