### PR TITLE
chore(release): prepare v0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.5.8 - 2026-08-14
 
 ### Dependencies
 
 - Update CrawlKit to v0.14.6, fixing TUI filter input, Unicode backspace handling, and overlapping refreshes; update Kong and indirect Go modules.
-
 ## 0.5.7 - 2026-08-02
 
 ### Fixed


### PR DESCRIPTION
Stamps the changelog for v0.5.8.