### PR TITLE
fix(mcp): reject repeated tools/list cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Reject a repeated Notion MCP `tools/list` nextCursor so a sticky pager cannot livelock sync.
+- Reject repeated Notion MCP `tools/list` cursors and cap discovery at 100 pages so a malformed pager cannot livelock sync.
 
 ## v0.5.8 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.9 - Unreleased
+
+### Fixed
+
+- Reject a repeated Notion MCP `tools/list` nextCursor so a sticky pager cannot livelock sync.
+
 ## v0.5.8 - 2026-08-14
 
 ### Dependencies

--- a/internal/notionmcp/client.go
+++ b/internal/notionmcp/client.go
@@ -678,6 +678,7 @@ func (c Client) validatedBaseURL() (string, error) {
 func (g *gatewayClient) listAllTools(ctx context.Context) ([]toolDefinition, error) {
 	var all []toolDefinition
 	cursor := ""
+	seen := map[string]bool{}
 	for {
 		params := map[string]any{}
 		if cursor != "" {
@@ -691,6 +692,10 @@ func (g *gatewayClient) listAllTools(ctx context.Context) ([]toolDefinition, err
 		if strings.TrimSpace(page.NextCursor) == "" {
 			return all, nil
 		}
+		if seen[page.NextCursor] {
+			return nil, fmt.Errorf("MCP tools/list repeated cursor %q", page.NextCursor)
+		}
+		seen[page.NextCursor] = true
 		cursor = page.NextCursor
 	}
 }

--- a/internal/notionmcp/client.go
+++ b/internal/notionmcp/client.go
@@ -18,7 +18,10 @@ import (
 	"github.com/openclaw/notcrawl/internal/store"
 )
 
-const defaultBaseURL = "https://chatgpt.com/backend-api/wham/apps"
+const (
+	defaultBaseURL    = "https://chatgpt.com/backend-api/wham/apps"
+	maxToolsListPages = 100
+)
 
 var (
 	pageIDPattern = regexp.MustCompile(`(?i)[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}`)
@@ -679,7 +682,7 @@ func (g *gatewayClient) listAllTools(ctx context.Context) ([]toolDefinition, err
 	var all []toolDefinition
 	cursor := ""
 	seen := map[string]bool{}
-	for {
+	for range maxToolsListPages {
 		params := map[string]any{}
 		if cursor != "" {
 			params["cursor"] = cursor
@@ -698,6 +701,7 @@ func (g *gatewayClient) listAllTools(ctx context.Context) ([]toolDefinition, err
 		seen[page.NextCursor] = true
 		cursor = page.NextCursor
 	}
+	return nil, fmt.Errorf("MCP tools/list exceeded %d pages", maxToolsListPages)
 }
 
 func (g *gatewayClient) fetchPage(ctx context.Context, toolName, ref string) (fetchResult, error) {

--- a/internal/notionmcp/client_test.go
+++ b/internal/notionmcp/client_test.go
@@ -3,6 +3,7 @@ package notionmcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -549,8 +550,27 @@ func TestListAllToolsRejectsRepeatedCursor(t *testing.T) {
 	}
 }
 
+func TestListAllToolsRejectsUnboundedUniqueCursors(t *testing.T) {
+	pager := &repeatingCursorPager{unique: true}
+	server := httptest.NewServer(http.HandlerFunc(pager.serve))
+	defer server.Close()
+
+	_, err := (&gatewayClient{
+		http:    server.Client(),
+		baseURL: server.URL,
+		auth:    authInfo{AccessToken: "test-token"},
+	}).listAllTools(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "exceeded 100 pages") {
+		t.Fatalf("err = %v, want page limit", err)
+	}
+	if pager.calls != maxToolsListPages {
+		t.Fatalf("tools/list calls = %d, want %d", pager.calls, maxToolsListPages)
+	}
+}
+
 type repeatingCursorPager struct {
 	cursor string
+	unique bool
 	calls  int
 }
 
@@ -568,13 +588,17 @@ func (p *repeatingCursorPager) serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p.calls++
-	if p.calls > 5 {
+	if !p.unique && p.calls > 5 {
 		http.Error(w, "sticky pager was not stopped", http.StatusInternalServerError)
 		return
 	}
+	cursor := p.cursor
+	if p.unique {
+		cursor = fmt.Sprintf("cursor-%d", p.calls)
+	}
 	writeRPCResult(w, request.ID, map[string]any{
 		"tools":      []map[string]any{{"name": "notion_fetch"}},
-		"nextCursor": p.cursor,
+		"nextCursor": cursor,
 	})
 }
 

--- a/internal/notionmcp/client_test.go
+++ b/internal/notionmcp/client_test.go
@@ -531,6 +531,53 @@ func TestClientRejectsUntrustedBaseURLBeforeReadingAuth(t *testing.T) {
 	}
 }
 
+func TestListAllToolsRejectsRepeatedCursor(t *testing.T) {
+	pager := &repeatingCursorPager{cursor: "same"}
+	server := httptest.NewServer(http.HandlerFunc(pager.serve))
+	defer server.Close()
+
+	_, err := (&gatewayClient{
+		http:    server.Client(),
+		baseURL: server.URL,
+		auth:    authInfo{AccessToken: "test-token"},
+	}).listAllTools(context.Background())
+	if err == nil || !strings.Contains(err.Error(), `repeated cursor "same"`) {
+		t.Fatalf("err = %v, want repeated cursor", err)
+	}
+	if pager.calls != 2 {
+		t.Fatalf("tools/list calls = %d, want 2", pager.calls)
+	}
+}
+
+type repeatingCursorPager struct {
+	cursor string
+	calls  int
+}
+
+func (p *repeatingCursorPager) serve(w http.ResponseWriter, r *http.Request) {
+	var request struct {
+		ID     any    `json:"id"`
+		Method string `json:"method"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if request.Method != "tools/list" {
+		http.Error(w, "unexpected method "+request.Method, http.StatusBadRequest)
+		return
+	}
+	p.calls++
+	if p.calls > 5 {
+		http.Error(w, "sticky pager was not stopped", http.StatusInternalServerError)
+		return
+	}
+	writeRPCResult(w, request.ID, map[string]any{
+		"tools":      []map[string]any{{"name": "notion_fetch"}},
+		"nextCursor": p.cursor,
+	})
+}
+
 func TestExtractEnhancedMarkdownPreservesProperties(t *testing.T) {
 	got := extractEnhancedMarkdown(`<page><properties>{"Status":"In progress"}</properties><content>Body</content></page>`)
 	for _, want := range []string{"## Properties", `    {"Status":"In progress"}`, "Body"} {


### PR DESCRIPTION
## What Problem This Solves

`listAllTools` followed MCP `nextCursor` with no cycle check. A sticky cursor makes `notcrawl sync` (MCP mode) loop `tools/list` forever. slacrawl already rejects a repeated cursor.

## Evidence

```console
Red:  TestListAllToolsRejectsRepeatedCursor
      err = Codex apps gateway returned HTTP 500, want repeated cursor
Green: 2 tools/list calls, error MCP tools/list repeated cursor "same"
```

## Real behavior proof
Behavior addressed: Repeated MCP `tools/list` cursors now fail closed instead of livelocking sync.
Real environment tested: macOS, Go from the worktree, notcrawl `/tmp/oc-impl-notcrawl` head `fce7a1f`.
Exact steps or command run after this patch: `go test -count=1 ./internal/notionmcp`
Evidence after fix: red/green recorded above.
Observed result after fix: a pager that always returns the same cursor errors on the second page.
What was not tested: A live Notion MCP gateway with a real sticky cursor.
