### PR TITLE
chore(deps): refresh dependencies

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
+        uses: trufflesecurity/trufflehog@bcfcf73aaf4759d4dadc2783177c245a02792318 # v3.97.0
         with:
           path: ./
           base: ${{ steps.scan_range.outputs.base }}

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.14.6
+	github.com/openclaw/crawlkit v0.14.7
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	modernc.org/libc v1.75.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.6 h1:NUEC9xu/IDzUv1rO/27aWNuTblvd3eYSooLfDn1RDvA=
-github.com/openclaw/crawlkit v0.14.6/go.mod h1:rLf+LwCKA4qSXD5JdKv0CDVJv8zMnhUH17tHxvKdd0U=
+github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+ArQ=
+github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
## Summary

- Refresh `github.com/openclaw/crawlkit` 0.14.6 → 0.14.7.
- Refresh immutable SHA-pinned `trufflesecurity/trufflehog` 3.96.0 → 3.97.0.
- Held: none.
- Supersedes Dependabot PRs #103 and #104.

## Verification

- `go mod tidy`
- `go vet ./...`
- `go test -count=1 ./...` — all 11 packages passed.
- `go build -o /private/tmp/t30-notcrawl ./cmd/notcrawl`
- Real compiled CLI smokes: `--help`, `--version`, `metadata --json`, and temporary-database `status --json` / `tui --json --limit 1`, all exit 0.
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` — no vulnerabilities found.
- Structured pre-commit Codex review: clean.
