### PR TITLE
feat(sync): add redacted verbose diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.9 - Unreleased
 
+### Added
+
+- Add per-invocation `sync --verbose` diagnostics on stderr with phases, counts, API attempts, HTTP statuses, and retry delays while excluding private request data and upstream errors. Thanks @transitive-bullshit.
+
 ### Dependencies
 
 - Update Go to 1.27.0, SQLite to v1.57.0, indirect Go modules, vulnerability and dead-code tooling, and the stale and secret-scanning GitHub Actions.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ export NOTION_TOKEN="secret_..."
 notcrawl sync --source api
 ```
 
+For a slow or stalled sync, add `--verbose` to that invocation:
+
+```sh
+notcrawl sync --source api --verbose
+```
+
+Verbose diagnostics go to stderr and report source phases, elapsed time, and counts. Official API sync also reports request attempts, endpoint classes, numeric HTTP statuses, and retry delays. No credentials, headers, request/response bodies, raw URLs, cursors, page identifiers, or upstream error text are logged. Warnings become counts and failures use a fixed message in verbose mode. Normal stdout is unchanged and may still contain local paths; without `--verbose`, the existing progress, warnings, and errors are unchanged. Desktop and MCP sync report source phases and counts, not per-request API traces.
+
 Notion MCP can repair known incomplete pages, fetch a page by ID or URL, or run a bounded workspace search:
 
 ```sh

--- a/SPEC.md
+++ b/SPEC.md
@@ -74,6 +74,8 @@ API sync uses `NOTION_TOKEN` by default. It must:
 5. obey `Retry-After` on rate limits
 6. store raw JSON plus normalized rows
 
+`sync --verbose` enables per-invocation stderr diagnostics for source phases and counts, with official API request attempts, endpoint classes, elapsed time, numeric HTTP statuses, and retry delays. Diagnostics use fixed labels and numeric fields, never credentials, headers, payloads, raw URLs, cursors, page identifiers, or upstream error text. Verbose mode replaces warning text with counts and sanitizes sync failures; stdout and non-verbose behavior remain unchanged.
+
 New configs should use the current Notion API version. Existing configs pinned
 to legacy `2022-06-28` must continue using deprecated database query endpoints.
 

--- a/cmd/notcrawl/main.go
+++ b/cmd/notcrawl/main.go
@@ -408,7 +408,9 @@ func runMaintain(ctx context.Context, stdout io.Writer, cfg config.Config, args 
 
 func runSync(ctx context.Context, stdout, stderr io.Writer, cfg config.Config, args []string) (err error) {
 	fs := flag.NewFlagSet("sync", flag.ContinueOnError)
+	fs.SetOutput(stderr)
 	source := fs.String("source", "all", "source: desktop, api, notion-mcp, all")
+	verbose := fs.Bool("verbose", false, "write redacted sync diagnostics to stderr")
 	limit := fs.Int("limit", cfg.Notion.MCP.MaxPages, "maximum Notion MCP pages to fetch; 0 means unlimited")
 	var pageIDs, queries stringListFlag
 	fs.Var(&pageIDs, "page", "Notion page ID or URL to fetch; repeatable")
@@ -422,12 +424,20 @@ func runSync(ctx context.Context, stdout, stderr io.Writer, cfg config.Config, a
 	if *source != "notion-mcp" && (len(pageIDs) > 0 || len(queries) > 0 || *limit != cfg.Notion.MCP.MaxPages) {
 		return fmt.Errorf("--page, --query, and --limit apply only to --source notion-mcp")
 	}
+	trace := newSyncTrace(stderr, *verbose)
+	defer func() { err = trace.finish(err) }()
+	trace.start("archive")
 	st, err := store.Open(cfg.DBPath)
 	if err != nil {
 		return err
 	}
 	defer st.Close()
-	tracker := progress.New(progressLogger(stderr), progress.Options{
+	trace.done()
+	progressOutput := stderr
+	if *verbose {
+		progressOutput = io.Discard
+	}
+	tracker := progress.New(progressLogger(progressOutput), progress.Options{
 		Name:  "sync",
 		Unit:  "stages",
 		Total: int64(syncStageTotal(*source, cfg)),
@@ -441,67 +451,89 @@ func runSync(ctx context.Context, stdout, stderr io.Writer, cfg config.Config, a
 	}()
 	switch *source {
 	case "desktop":
+		trace.start("desktop")
 		s, err := notiondesktop.Ingest(ctx, st, cfg.Notion.Desktop.Path, cfg.CacheDir)
 		if err != nil {
 			return err
 		}
 		completed++
 		tracker.Set(completed, "phase", "desktop", "pages", s.Pages, "blocks", s.Blocks, "collections", s.Collections)
+		trace.done("pages", s.Pages, "blocks", s.Blocks, "collections", s.Collections, "comments", s.Comments)
 		fmt.Fprintf(stdout, "desktop: pages=%d blocks=%d teams=%d collections=%d comments=%d snapshot=%s\n", s.Pages, s.Blocks, s.Teams, s.Collections, s.Comments, s.Source.Snapshot)
 	case "api":
+		trace.start("api")
 		s, err := notionapi.Client{
 			BaseURL: cfg.Notion.API.BaseURL,
 			Version: cfg.Notion.API.Version,
 			Token:   cfg.APIToken(),
+			Trace:   trace.apiLogger(),
 		}.Sync(ctx, st)
 		if err != nil {
 			return err
 		}
 		completed++
 		tracker.Set(completed, "phase", "api", "pages", s.Pages, "databases", s.Databases, "blocks", s.Blocks)
-		writeAPIWarnings(stderr, s)
+		trace.done("users", s.Users, "pages", s.Pages, "databases", s.Databases, "database_rows", s.DatabaseRows, "blocks", s.Blocks, "comments", s.Comments, "warnings", len(s.Warnings))
+		if !*verbose {
+			writeAPIWarnings(stderr, s)
+		}
 		fmt.Fprintf(stdout, "api: users=%d pages=%d databases=%d database_rows=%d blocks=%d comments=%d\n", s.Users, s.Pages, s.Databases, s.DatabaseRows, s.Blocks, s.Comments)
 	case "notion-mcp":
+		trace.start("notion-mcp")
 		s, err := syncNotionMCP(ctx, st, cfg, notionmcp.SyncOptions{PageIDs: pageIDs, Queries: queries, Limit: *limit})
 		if err != nil {
 			return err
 		}
 		completed++
 		tracker.Set(completed, "phase", "notion-mcp", "candidates", s.Candidates, "pages", s.Pages, "failed", s.Failed)
-		writeNotionMCPWarnings(stderr, s)
+		trace.done("candidates", s.Candidates, "pages", s.Pages, "empty", s.EmptyPages, "failed", s.Failed, "warnings", len(s.Warnings))
+		if !*verbose {
+			writeNotionMCPWarnings(stderr, s)
+		}
 		fmt.Fprintf(stdout, "notion-mcp: candidates=%d pages=%d empty=%d failed=%d\n", s.Candidates, s.Pages, s.EmptyPages, s.Failed)
 	case "all":
 		if cfg.Notion.Desktop.Enabled {
+			trace.start("desktop")
 			s, err := notiondesktop.Ingest(ctx, st, cfg.Notion.Desktop.Path, cfg.CacheDir)
 			if err != nil {
 				return err
 			}
 			completed++
 			tracker.Set(completed, "phase", "desktop", "pages", s.Pages, "blocks", s.Blocks, "collections", s.Collections)
+			trace.done("pages", s.Pages, "blocks", s.Blocks, "collections", s.Collections, "comments", s.Comments)
 			fmt.Fprintf(stdout, "desktop: pages=%d blocks=%d teams=%d collections=%d comments=%d snapshot=%s\n", s.Pages, s.Blocks, s.Teams, s.Collections, s.Comments, s.Source.Snapshot)
 		}
 		if cfg.Notion.API.Enabled && cfg.APIToken() != "" {
+			trace.start("api")
 			s, err := notionapi.Client{
 				BaseURL: cfg.Notion.API.BaseURL,
 				Version: cfg.Notion.API.Version,
 				Token:   cfg.APIToken(),
+				Trace:   trace.apiLogger(),
 			}.Sync(ctx, st)
 			if err != nil {
 				return err
 			}
 			completed++
 			tracker.Set(completed, "phase", "api", "pages", s.Pages, "databases", s.Databases, "blocks", s.Blocks)
-			writeAPIWarnings(stderr, s)
+			trace.done("users", s.Users, "pages", s.Pages, "databases", s.Databases, "database_rows", s.DatabaseRows, "blocks", s.Blocks, "comments", s.Comments, "warnings", len(s.Warnings))
+			if !*verbose {
+				writeAPIWarnings(stderr, s)
+			}
 			fmt.Fprintf(stdout, "api: users=%d pages=%d databases=%d database_rows=%d blocks=%d comments=%d\n", s.Users, s.Pages, s.Databases, s.DatabaseRows, s.Blocks, s.Comments)
 		}
 		if cfg.Notion.MCP.Enabled {
+			trace.start("notion-mcp")
 			s, err := syncNotionMCP(ctx, st, cfg, notionmcp.SyncOptions{Limit: cfg.Notion.MCP.MaxPages})
 			if err != nil {
 				return err
 			}
 			completed++
 			tracker.Set(completed, "phase", "notion-mcp", "candidates", s.Candidates, "pages", s.Pages, "failed", s.Failed)
-			writeNotionMCPWarnings(stderr, s)
+			trace.done("candidates", s.Candidates, "pages", s.Pages, "empty", s.EmptyPages, "failed", s.Failed, "warnings", len(s.Warnings))
+			if !*verbose {
+				writeNotionMCPWarnings(stderr, s)
+			}
 			fmt.Fprintf(stdout, "notion-mcp: candidates=%d pages=%d empty=%d failed=%d\n", s.Candidates, s.Pages, s.EmptyPages, s.Failed)
 		}
 	default:

--- a/cmd/notcrawl/sync_trace.go
+++ b/cmd/notcrawl/sync_trace.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"time"
+)
+
+type syncTrace struct {
+	logger  *slog.Logger
+	started time.Time
+	phase   string
+}
+
+func newSyncTrace(w io.Writer, enabled bool) *syncTrace {
+	if !enabled {
+		return nil
+	}
+	return &syncTrace{logger: progressLogger(w), started: time.Now()}
+}
+
+func (t *syncTrace) start(phase string) {
+	if t == nil {
+		return
+	}
+	t.phase = phase
+	t.emit(phase, "started")
+}
+
+func (t *syncTrace) done(counts ...any) {
+	if t == nil {
+		return
+	}
+	t.emit(t.phase, "finished", counts...)
+}
+
+func (t *syncTrace) finish(err error) error {
+	if t == nil {
+		return err
+	}
+	if err != nil {
+		t.emit(t.phase, "failed")
+		// Upstream errors and warnings can contain URLs, identifiers, or content.
+		// The normal CLI retains them; verbose diagnostics never format them.
+		return errors.New("sync failed; verbose diagnostics omit private error details")
+	}
+	t.emit("sync", "finished")
+	return nil
+}
+
+func (t *syncTrace) emit(phase, state string, counts ...any) {
+	attrs := []any{"phase", phase, "state", state, "elapsed", time.Since(t.started).Round(time.Millisecond)}
+	t.logger.Info("sync trace", append(attrs, counts...)...)
+}
+
+func (t *syncTrace) apiLogger() *slog.Logger {
+	if t == nil {
+		return nil
+	}
+	return t.logger
+}

--- a/cmd/notcrawl/sync_trace_test.go
+++ b/cmd/notcrawl/sync_trace_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestSyncVerboseAPITraceAndRedaction(t *testing.T) {
+	const private = "private-workspace-marker"
+	usersRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch strings.TrimPrefix(r.URL.Path, "/"+private) {
+		case "/users":
+			usersRequests++
+			if usersRequests == 1 {
+				w.Header().Set("Retry-After", "0.001")
+				w.WriteHeader(http.StatusTooManyRequests)
+				fmt.Fprintf(w, `{"message":%q}`, private)
+			} else if r.URL.Query().Get("start_cursor") == "" {
+				fmt.Fprintf(w, `{"results":[{"id":%q,"name":%q}],"has_more":true,"next_cursor":%q}`, private, private, private)
+			} else {
+				fmt.Fprint(w, `{"results":[],"has_more":false}`)
+			}
+		case "/search":
+			var body bytes.Buffer
+			_, _ = body.ReadFrom(r.Body)
+			if strings.Contains(body.String(), `"value":"page"`) {
+				fmt.Fprintf(w, `{"results":[{"id":%q,"properties":{"title":{"title":[{"plain_text":%q}]}},"parent":{"type":"workspace","workspace":true}}]}`, private, private)
+			} else {
+				fmt.Fprint(w, `{"results":[]}`)
+			}
+		case "/blocks/" + private + "/children":
+			fmt.Fprintf(w, `{"results":[{"id":"block-private","type":"paragraph","has_children":true,"paragraph":{"rich_text":[{"plain_text":%q}]}}]}`, private)
+		case "/blocks/block-private/children":
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{"code":"validation_error","message":%q}`, private+" not supported via the API")
+		case "/comments":
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintf(w, `{"code":"restricted_resource","message":%q}`, private)
+		default:
+			http.Error(w, private, http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	configPath := syncTraceAPIConfig(t, server.URL+"/"+private)
+	var normalOut, normalErr bytes.Buffer
+	args := []string{"--config", configPath, "sync", "--source", "api"}
+	if err := run(context.Background(), args, &normalOut, &normalErr); err != nil {
+		t.Fatal(err)
+	}
+	usersRequests = 0
+	var verboseOut, verboseErr bytes.Buffer
+	if err := run(context.Background(), append(args, "--verbose"), &verboseOut, &verboseErr); err != nil {
+		t.Fatal(err)
+	}
+	if verboseOut.String() != normalOut.String() {
+		t.Fatalf("verbose changed stdout: %q != %q", verboseOut.String(), normalOut.String())
+	}
+	logs := verboseErr.String()
+	for _, want := range []string{`msg="sync trace"`, `phase=api`, `phase=users`, `phase=pages`, `phase=collections`, `state=started`, `state=finished`, `elapsed=`, `attempt=1`, `attempt=2`, `state=retry`, `status=429`, `status=200`, `status=403`, `retry_after=1ms`, `users=1`, `pages=1`, `blocks=1`, `warnings=1`} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("missing %q in trace:\n%s", want, logs)
+		}
+	}
+	for _, secret := range []string{private, "block-private", "test-token", server.URL, "Authorization", "Bearer", "start_cursor", "restricted_resource"} {
+		if strings.Contains(logs, secret) {
+			t.Errorf("private data %q in trace:\n%s", secret, logs)
+		}
+	}
+	if usersRequests != 3 {
+		t.Fatalf("users requests = %d, want 3 (retry and pagination)", usersRequests)
+	}
+	// The flag must not leak into later invocations in the same process.
+	usersRequests = 0
+	var offOut, offErr bytes.Buffer
+	if err := run(context.Background(), append(args, "--verbose=false"), &offOut, &offErr); err != nil {
+		t.Fatal(err)
+	}
+	// Wall-clock progress duration is the only non-deterministic output field.
+	elapsed := regexp.MustCompile(`elapsed=[^ ]+`)
+	if offOut.String() != normalOut.String() || elapsed.ReplaceAllString(offErr.String(), "elapsed=<time>") != elapsed.ReplaceAllString(normalErr.String(), "elapsed=<time>") {
+		t.Fatalf("disabled verbose changed normal output:\nstdout %q / %q\nstderr %q / %q", offOut.String(), normalOut.String(), offErr.String(), normalErr.String())
+	}
+}
+
+func TestSyncVerboseSanitizesFailure(t *testing.T) {
+	const private = "private-error-marker"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintf(w, `{"code":%q,"message":%q}`, private, private)
+	}))
+	defer server.Close()
+	configPath := syncTraceAPIConfig(t, server.URL+"/"+private)
+	for _, verbose := range []bool{false, true} {
+		var stdout, stderr bytes.Buffer
+		args := []string{"--config", configPath, "sync", "--source", "api", fmt.Sprintf("--verbose=%t", verbose)}
+		err := run(context.Background(), args, &stdout, &stderr)
+		if err == nil {
+			t.Fatal("expected API failure")
+		}
+		logs := stderr.String() + err.Error()
+		if verbose {
+			for _, secret := range []string{private, server.URL, "test-token"} {
+				if strings.Contains(logs, secret) {
+					t.Fatalf("private data %q in verbose failure: %s", secret, logs)
+				}
+			}
+			for _, want := range []string{"status=401", "state=failed", "phase=users", "sync failed"} {
+				if !strings.Contains(logs, want) {
+					t.Fatalf("missing %q in failure trace: %s", want, logs)
+				}
+			}
+		} else if !strings.Contains(logs, private) || strings.Contains(logs, `msg="sync trace"`) {
+			t.Fatalf("normal error output changed: %s", logs)
+		}
+	}
+}
+
+func TestSyncVerboseAllSourcesAndLocalFailure(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(fmt.Sprintf(`db_path = %q
+[notion.desktop]
+enabled = true
+path = %q
+[notion.api]
+enabled = false
+[notion.mcp]
+enabled = false
+`, filepath.Join(dir, "archive.db"), filepath.Join(dir, "private-desktop-path"))), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(context.Background(), []string{"--config", configPath, "sync", "--verbose"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"phase=archive", "phase=desktop", "pages=0", "blocks=0", "phase=sync state=finished"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("missing %q in source trace: %s", want, stderr.String())
+		}
+	}
+	if strings.Contains(stderr.String(), dir) {
+		t.Fatalf("local path leaked: %s", stderr.String())
+	}
+	// Opening a directory as SQLite fails before source ingestion begins.
+	stderr.Reset()
+	err := run(context.Background(), []string{"--config", configPath, "--db", dir, "sync", "--verbose"}, &stdout, &stderr)
+	if err == nil || strings.Contains(stderr.String()+err.Error(), dir) || !strings.Contains(stderr.String(), "phase=archive state=failed") {
+		t.Fatalf("unsafe or missing archive failure: %v / %s", err, stderr.String())
+	}
+}
+
+func syncTraceAPIConfig(t *testing.T, baseURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("NOTCRAWL_TRACE_TEST_TOKEN", "test-token")
+	path := filepath.Join(dir, "config.toml")
+	body := fmt.Sprintf("db_path = %q\n[notion.api]\nbase_url = %q\ntoken_env = %q\n", filepath.Join(dir, "archive.db"), baseURL, "NOTCRAWL_TRACE_TEST_TOKEN")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,6 +41,7 @@ type Client struct {
 	Version string
 	Token   string
 	HTTP    *http.Client
+	Trace   *slog.Logger
 }
 
 type Summary struct {
@@ -65,6 +67,8 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 	c.HTTP = httpClientOrDefault(c.HTTP)
 	var s Summary
 	if err := st.DeferPageFTS(ctx, func() error {
+		started := time.Now()
+		c.tracePhase("users", "started", started)
 		users, err := c.listUsers(ctx)
 		if err != nil {
 			if !isRestrictedResourceError(err) {
@@ -82,6 +86,9 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 				s.Users++
 			}
 		}
+		c.tracePhase("users", "finished", started, "users", s.Users)
+		started = time.Now()
+		c.tracePhase("pages", "started", started)
 		pages, err := c.searchPages(ctx)
 		if err != nil {
 			return err
@@ -95,7 +102,11 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 			s.Blocks += count
 			s.Comments += comments
 			s.Warnings = append(s.Warnings, warnings...)
+			c.tracePhase("pages", "progress", started, "pages", s.Pages, "blocks", s.Blocks, "comments", s.Comments)
 		}
+		c.tracePhase("pages", "finished", started, "pages", s.Pages, "blocks", s.Blocks, "comments", s.Comments)
+		started = time.Now()
+		c.tracePhase("collections", "started", started)
 		collections, err := c.searchCollections(ctx)
 		if err != nil {
 			return err
@@ -109,7 +120,9 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 			}
 			s.Databases++
 			s.DatabaseRows += rows
+			c.tracePhase("collections", "progress", started, "databases", s.Databases, "database_rows", s.DatabaseRows)
 		}
+		c.tracePhase("collections", "finished", started, "databases", s.Databases, "database_rows", s.DatabaseRows)
 		if s.Pages == 0 && s.Databases == 0 && s.Blocks == 0 && s.Comments == 0 {
 			status, err := st.Status(ctx)
 			if err != nil {
@@ -568,12 +581,15 @@ func (c Client) do(ctx context.Context, method, path string, body any, out any) 
 		bodyBytes = b
 	}
 	for attempt := 1; attempt <= maxAPIAttempts; attempt++ {
+		started := time.Now()
+		c.traceRequest(path, "started", attempt, 0, started, 0)
 		var reader io.Reader
 		if bodyBytes != nil {
 			reader = bytes.NewReader(bodyBytes)
 		}
 		req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(c.BaseURL, "/")+path, reader)
 		if err != nil {
+			c.traceRequest(path, "request_error", attempt, 0, started, 0)
 			return err
 		}
 		req.Header.Set("Authorization", "Bearer "+c.Token)
@@ -584,7 +600,9 @@ func (c Client) do(ctx context.Context, method, path string, body any, out any) 
 		}
 		resp, err := c.HTTP.Do(req)
 		if err != nil {
+			c.traceRequest(path, "transport_error", attempt, 0, started, 0)
 			if attempt < maxAPIAttempts && shouldRetryTransportError(ctx, method, path, err) {
+				c.traceRequest(path, "retry", attempt, 0, started, 0)
 				if err := waitBeforeRetry(ctx, 0); err != nil {
 					return err
 				}
@@ -592,11 +610,14 @@ func (c Client) do(ctx context.Context, method, path string, body any, out any) 
 			}
 			return err
 		}
+		c.traceRequest(path, "received", attempt, resp.StatusCode, started, 0)
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			responseBody, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			if readErr != nil {
+				c.traceRequest(path, "read_error", attempt, resp.StatusCode, started, 0)
 				if attempt < maxAPIAttempts && shouldRetryTransportError(ctx, method, path, readErr) {
+					c.traceRequest(path, "retry", attempt, resp.StatusCode, started, 0)
 					if err := waitBeforeRetry(ctx, 0); err != nil {
 						return err
 					}
@@ -604,13 +625,21 @@ func (c Client) do(ctx context.Context, method, path string, body any, out any) 
 				}
 				return readErr
 			}
-			return json.Unmarshal(responseBody, out)
+			err := json.Unmarshal(responseBody, out)
+			state := "finished"
+			if err != nil {
+				state = "decode_error"
+			}
+			c.traceRequest(path, state, attempt, resp.StatusCode, started, 0)
+			return err
 		}
 
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		resp.Body.Close()
+		c.traceRequest(path, "failed", attempt, resp.StatusCode, started, 0)
 		apiErr := apiErrorFromResponse(method, path, resp, b)
 		if attempt < maxAPIAttempts && shouldRetry(apiErr) {
+			c.traceRequest(path, "retry", attempt, resp.StatusCode, started, apiErr.RetryAfter)
 			if err := waitBeforeRetry(ctx, apiErr.RetryAfter); err != nil {
 				return err
 			}

--- a/internal/notionapi/trace.go
+++ b/internal/notionapi/trace.go
@@ -1,0 +1,52 @@
+package notionapi
+
+import (
+	"strings"
+	"time"
+)
+
+// Trace fields come only from fixed labels, durations, and counts. Never pass
+// request/response data or errors to the logger, even on failure paths.
+func (c Client) tracePhase(phase, state string, started time.Time, counts ...any) {
+	if c.Trace == nil {
+		return
+	}
+	attrs := []any{"phase", phase, "state", state, "elapsed", time.Since(started).Round(time.Millisecond)}
+	c.Trace.Info("sync trace", append(attrs, counts...)...)
+}
+
+func (c Client) traceRequest(path, state string, attempt, statusCode int, started time.Time, retryAfter time.Duration) {
+	if c.Trace == nil {
+		return
+	}
+	attrs := []any{
+		"phase", "request", "operation", traceOperation(path), "state", state,
+		"attempt", attempt, "elapsed", time.Since(started).Round(time.Millisecond),
+	}
+	if statusCode != 0 {
+		attrs = append(attrs, "status", statusCode)
+	}
+	if state == "retry" {
+		attrs = append(attrs, "retry_after", retryAfter)
+	}
+	c.Trace.Info("sync trace", attrs...)
+}
+
+func traceOperation(path string) string {
+	path, _, _ = strings.Cut(path, "?")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	switch {
+	case path == "/users":
+		return "users.list"
+	case path == "/search":
+		return "search"
+	case path == "/comments":
+		return "comments.list"
+	case len(parts) == 3 && parts[0] == "blocks" && parts[2] == "children":
+		return "blocks.children"
+	case len(parts) == 3 && (parts[0] == "databases" || parts[0] == "data_sources") && parts[2] == "query":
+		return "collections.query"
+	default:
+		return "other"
+	}
+}

--- a/internal/notionapi/trace_test.go
+++ b/internal/notionapi/trace_test.go
@@ -1,0 +1,76 @@
+package notionapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRequestTraceRedactsTransportAndBodyErrors(t *testing.T) {
+	for _, failure := range []string{"transport_error", "read_error", "decode_error"} {
+		t.Run(failure, func(t *testing.T) {
+			var logs bytes.Buffer
+			attempts := 0
+			client := Client{
+				BaseURL: "https://private-host.invalid/private-base",
+				Token:   "test-token",
+				Trace:   slog.New(slog.NewTextHandler(&logs, nil)),
+				HTTP: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					attempts++
+					if failure == "transport_error" {
+						return nil, errors.New("private-transport-error")
+					}
+					body := io.ReadCloser(io.NopCloser(strings.NewReader("private-invalid-json")))
+					if failure == "read_error" {
+						body = &errorAfterDataReadCloser{data: []byte("private-body"), err: errors.New("private-read-error")}
+					}
+					return &http.Response{StatusCode: 200, Status: "200 private-status", Body: body, Header: http.Header{"Private-Header": []string{"private-header"}}}, nil
+				})},
+			}
+			var out obj
+			err := client.do(context.Background(), http.MethodGet, "/blocks/private-page/children?start_cursor=private-cursor", nil, &out)
+			if err == nil {
+				t.Fatal("expected request failure")
+			}
+			if strings.Contains(logs.String(), "private") || strings.Contains(logs.String(), "test-token") {
+				t.Fatalf("trace leaked request or error data: %s", logs.String())
+			}
+			for _, want := range []string{"operation=blocks.children", "state=" + failure, "attempt=1", "elapsed="} {
+				if !strings.Contains(logs.String(), want) {
+					t.Fatalf("missing %q in trace: %s", want, logs.String())
+				}
+			}
+			wantAttempts := 4
+			if failure == "decode_error" {
+				wantAttempts = 1
+			} else if strings.Count(logs.String(), "state=retry") != 3 {
+				t.Fatalf("expected three retry events: %s", logs.String())
+			}
+			if attempts != wantAttempts {
+				t.Fatalf("attempts = %d, want %d", attempts, wantAttempts)
+			}
+		})
+	}
+}
+
+func TestTraceOperationNeverReturnsIdentifiers(t *testing.T) {
+	for path, want := range map[string]string{
+		"/users?start_cursor=private":                   "users.list",
+		"/search":                                       "search",
+		"/comments?block_id=private":                    "comments.list",
+		"/blocks/private/children?start_cursor=private": "blocks.children",
+		"/databases/private/query":                      "collections.query",
+		"/data_sources/private/query":                   "collections.query",
+		"/private?token=private":                        "other",
+		"https://private.invalid/users":                 "other",
+	} {
+		if got := traceOperation(path); got != want {
+			t.Errorf("traceOperation(%q) = %q, want %q", path, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

API sync reports source-level progress only after `Client.Sync` returns. The HTTP client has no request or retry diagnostics, so a slow request, repeated pagination, retry delay, and local ingestion all look like the same stalled operation. Adding a verbose flag at the CLI alone would not expose the work inside that call.

## Change

Add per-invocation `sync --verbose`. It writes source phases, elapsed time, and counts to stderr; official API sync additionally traces discovery phases, endpoint classes, attempts, received HTTP status codes, completion, and retries. Request-start events appear before network I/O, and status events appear before reading the response body. Desktop and MCP receive source-level diagnostics only.

The trace uses fixed labels, durations, and numeric fields instead of dumping request objects or interpolating errors. Credentials, headers, bodies, raw URLs, cursors, and page identifiers are excluded. Verbose warnings become counts and sync failures use a fixed message, preventing existing upstream error formatting from leaking private data into the diagnostic stream. Stdout is unchanged; the existing progress, warning, and error paths remain in use when verbose is disabled. No retry or pagination policy changes.

README, SPEC, and the Unreleased changelog document the new mode and its limits.

## Proof

- Before implementation, the new CLI regression failed because `--verbose` was undefined.
- `make check` passed all gates: dependency verification and vulnerability scan, formatting, vet/dead-code analysis, **147 tests across 11 packages**, release-script tests, CLI smoke, both release-config checks, and both credential-free snapshot builds. No artifacts were published.
- `GOWORK=off go test -race -count=1 ./cmd/notcrawl ./internal/notionapi -run 'Test(SyncVerbose|RequestTrace|TraceOperation)'` passed.
- Codex autoreview completed with no actionable findings at its default review threshold.
- Ran the actual built CLI against a loopback HTTP fixture in **12 invocations / 64 requests** covering successful ingestion, a partial-block warning, and an HTTP 401 failure. Each scenario compared original main (`a2bee8e`), the new binary with the flag absent, `--verbose`, and `--verbose=false`.
- Each successful fixture run ingested **1 user, 1 page, and 1 block**. The success scenario made **7 requests**, including HTTP 429 retry and cursor pagination; the warning scenario made **8 requests**, including a safely summarized HTTP 400 warning; the failure scenario stopped after **1 request**.
- Stdout matched original main byte-for-byte in every mode. Disabled-mode stderr matched apart from existing elapsed-time values; five of six comparisons also matched those timing bytes exactly. Raw logs were retained, and the only normalization used was the pre-existing `elapsed` field.
- Verbose logs showed HTTP 429/200/400/401 statuses, retry delay, attempts, phases, and counts, with **zero private fixture markers** from credentials, URLs, cursors, identifiers, bodies, headers, or upstream errors. Unit tests also cover transport/read/decode failures, source selection, local archive failures, and per-invocation flag isolation.

Built-binary invocation pattern:

```sh
notcrawl --config <isolated-fixture.toml> sync --source api
notcrawl --config <isolated-fixture.toml> sync --source api --verbose
notcrawl --config <isolated-fixture.toml> sync --source api --verbose=false
```

No authenticated Notion workspace was used. This adds the requested diagnostic surface; it does not claim to identify or fix the original reported hang.

Fixes #100
