### PR TITLE
fix(api): detect pagination cursor cycles without capping listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Reject repeated official API cursors without limiting healthy pagination or rewriting opaque cursor values. Thanks @SebTardif.
 - Reject repeated Notion MCP `tools/list` cursors and cap discovery at 100 pages so a malformed pager cannot livelock sync.
 
 ## v0.5.8 - 2026-08-14

--- a/SPEC.md
+++ b/SPEC.md
@@ -74,6 +74,8 @@ API sync uses `NOTION_TOKEN` by default. It must:
 5. obey `Retry-After` on rate limits
 6. store raw JSON plus normalized rows
 
+Official API pagination treats cursors as opaque values and rejects repeated cursors within each listing, without imposing a fixed page-count limit. Pagination failures must not mark an incomplete page sync complete or retire cached blocks that were not reached. Error messages identify the operation without including cursor values.
+
 `sync --verbose` enables per-invocation stderr diagnostics for source phases and counts, with official API request attempts, endpoint classes, elapsed time, numeric HTTP statuses, and retry delays. Diagnostics use fixed labels and numeric fields, never credentials, headers, payloads, raw URLs, cursors, page identifiers, or upstream error text. Verbose mode replaces warning text with counts and sanitizes sync failures; stdout and non-verbose behavior remain unchanged.
 
 New configs should use the current Notion API version. Existing configs pinned

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -167,9 +167,26 @@ func (o obj) mapObj(key string) obj {
 	return nil
 }
 
+func nextListCursor(resp obj, seen map[string]bool, op string) (string, bool, error) {
+	if !truthy(resp["has_more"]) {
+		return "", false, nil
+	}
+	cursor, _ := resp["next_cursor"].(string)
+	if cursor == "" {
+		return "", false, nil
+	}
+	// Cursors are opaque. Compare exact values without limiting healthy listings.
+	if seen[cursor] {
+		return "", false, fmt.Errorf("%s repeated cursor", op)
+	}
+	seen[cursor] = true
+	return cursor, true, nil
+}
+
 func (c Client) listUsers(ctx context.Context) ([]obj, error) {
 	var out []obj
 	cursor := ""
+	seen := map[string]bool{}
 	for {
 		path := "/users?page_size=100"
 		if cursor != "" {
@@ -184,13 +201,14 @@ func (c Client) listUsers(ctx context.Context) ([]obj, error) {
 				out = append(out, obj(m))
 			}
 		}
-		if !truthy(resp["has_more"]) {
+		next, more, err := nextListCursor(resp, seen, "Notion users/list")
+		if err != nil {
+			return nil, err
+		}
+		if !more {
 			return out, nil
 		}
-		cursor, _ = resp["next_cursor"].(string)
-		if cursor == "" {
-			return out, nil
-		}
+		cursor = next
 	}
 }
 
@@ -205,6 +223,7 @@ func (c Client) searchCollections(ctx context.Context) ([]obj, error) {
 func (c Client) searchObjects(ctx context.Context, objectType string) ([]obj, error) {
 	var out []obj
 	cursor := ""
+	seen := map[string]bool{}
 	for {
 		body := obj{"page_size": 100, "filter": obj{"property": "object", "value": objectType}}
 		if cursor != "" {
@@ -219,13 +238,14 @@ func (c Client) searchObjects(ctx context.Context, objectType string) ([]obj, er
 				out = append(out, obj(m))
 			}
 		}
-		if !truthy(resp["has_more"]) {
+		next, more, err := nextListCursor(resp, seen, "Notion search")
+		if err != nil {
+			return nil, err
+		}
+		if !more {
 			return out, nil
 		}
-		cursor, _ = resp["next_cursor"].(string)
-		if cursor == "" {
-			return out, nil
-		}
+		cursor = next
 	}
 }
 
@@ -354,6 +374,7 @@ func (c Client) ingestCollection(ctx context.Context, st *store.Store, collectio
 func (c Client) queryCollection(ctx context.Context, st *store.Store, collectionID string) (int, error) {
 	var count int
 	cursor := ""
+	seen := map[string]bool{}
 	for {
 		body := obj{"page_size": 100}
 		if cursor != "" {
@@ -385,13 +406,14 @@ func (c Client) queryCollection(ctx context.Context, st *store.Store, collection
 			}
 			count++
 		}
-		if !truthy(resp["has_more"]) {
+		next, more, err := nextListCursor(resp, seen, "Notion collection query")
+		if err != nil {
+			return count, err
+		}
+		if !more {
 			return count, nil
 		}
-		cursor, _ = resp["next_cursor"].(string)
-		if cursor == "" {
-			return count, nil
-		}
+		cursor = next
 	}
 }
 
@@ -438,6 +460,7 @@ func (c Client) walkBlocksAt(ctx context.Context, st *store.Store, pageID, paren
 	var count int
 	var warnings []string
 	cursor := ""
+	seen := map[string]bool{}
 	var displayOrder int64
 	for {
 		path := fmt.Sprintf("/blocks/%s/children?page_size=100", url.PathEscape(parentID))
@@ -493,13 +516,14 @@ func (c Client) walkBlocksAt(ctx context.Context, st *store.Store, pageID, paren
 				count += n
 			}
 		}
-		if !truthy(resp["has_more"]) {
+		next, more, err := nextListCursor(resp, seen, "Notion block children")
+		if err != nil {
+			return count, warnings, err
+		}
+		if !more {
 			return count, warnings, nil
 		}
-		cursor, _ = resp["next_cursor"].(string)
-		if cursor == "" {
-			return count, warnings, nil
-		}
+		cursor = next
 	}
 }
 
@@ -524,6 +548,7 @@ func isSyncedBlockCopy(block obj) bool {
 func (c Client) ingestComments(ctx context.Context, st *store.Store, pageID, spaceID string) (int, error) {
 	var count int
 	cursor := ""
+	seen := map[string]bool{}
 	for {
 		path := "/comments?block_id=" + url.QueryEscape(pageID) + "&page_size=100"
 		if cursor != "" {
@@ -561,13 +586,14 @@ func (c Client) ingestComments(ctx context.Context, st *store.Store, pageID, spa
 			}
 			count++
 		}
-		if !truthy(resp["has_more"]) {
+		next, more, err := nextListCursor(resp, seen, "Notion comments/list")
+		if err != nil {
+			return count, err
+		}
+		if !more {
 			return count, nil
 		}
-		cursor, _ = resp["next_cursor"].(string)
-		if cursor == "" {
-			return count, nil
-		}
+		cursor = next
 	}
 }
 

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1025,4 +1026,62 @@ func TestSyncUsesDefaultHTTPClientWhenHTTPNil(t *testing.T) {
 	if _, err := client.Sync(context.Background(), st); err != nil {
 		t.Fatalf("Sync with nil HTTP: %v", err)
 	}
+}
+
+func TestListUsersRejectsRepeatedCursor(t *testing.T) {
+	pager := &repeatingListCursorPager{cursor: "same"}
+	server := httptest.NewServer(http.HandlerFunc(pager.serve))
+	defer server.Close()
+
+	_, err := (Client{
+		BaseURL: server.URL,
+		Version: "2022-06-28",
+		Token:   "secret",
+		HTTP:    server.Client(),
+	}).listUsers(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "repeated cursor") {
+		t.Fatalf("err = %v, want repeated cursor", err)
+	}
+	if pager.calls != 2 {
+		t.Fatalf("users/list calls = %d, want 2", pager.calls)
+	}
+}
+
+func TestNextListCursorRejectsRepeatedAndEmpty(t *testing.T) {
+	seen := map[string]bool{}
+	next, more, err := nextListCursor(obj{"has_more": true, "next_cursor": "abc"}, seen, "Notion users/list")
+	if err != nil || !more || next != "abc" {
+		t.Fatalf("first cursor: next=%q more=%v err=%v", next, more, err)
+	}
+	_, more, err = nextListCursor(obj{"has_more": true, "next_cursor": "abc"}, seen, "Notion users/list")
+	if err == nil || !strings.Contains(err.Error(), "repeated cursor") || more {
+		t.Fatalf("repeated: more=%v err=%v", more, err)
+	}
+	next, more, err = nextListCursor(obj{"has_more": true, "next_cursor": ""}, seen, "Notion users/list")
+	if err != nil || more || next != "" {
+		t.Fatalf("empty cursor: next=%q more=%v err=%v", next, more, err)
+	}
+	next, more, err = nextListCursor(obj{"has_more": false, "next_cursor": "abc"}, seen, "Notion users/list")
+	if err != nil || more || next != "" {
+		t.Fatalf("has_more false: next=%q more=%v err=%v", next, more, err)
+	}
+}
+
+type repeatingListCursorPager struct {
+	cursor string
+	calls  int
+}
+
+func (p *repeatingListCursorPager) serve(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/users" {
+		http.Error(w, "unexpected path "+r.URL.Path, http.StatusBadRequest)
+		return
+	}
+	p.calls++
+	if p.calls > 5 {
+		http.Error(w, "sticky pager was not stopped", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprintf(w, `{"object":"list","results":[],"has_more":true,"next_cursor":%q}`, p.cursor)
 }

--- a/internal/notionapi/pagination_test.go
+++ b/internal/notionapi/pagination_test.go
@@ -1,0 +1,190 @@
+package notionapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestAPIPagination(t *testing.T) {
+	for _, endpoint := range []struct {
+		name, path, version string
+		run                 func(context.Context, Client, *store.Store) (int, error)
+	}{
+		{"users", "/users", "2026-03-11", func(ctx context.Context, c Client, _ *store.Store) (int, error) {
+			items, err := c.listUsers(ctx)
+			return len(items), err
+		}},
+		{"pages", "/search", "2026-03-11", func(ctx context.Context, c Client, _ *store.Store) (int, error) {
+			items, err := c.searchPages(ctx)
+			return len(items), err
+		}},
+		{"collections", "/search", "2026-03-11", func(ctx context.Context, c Client, _ *store.Store) (int, error) {
+			items, err := c.searchCollections(ctx)
+			return len(items), err
+		}},
+		{"legacy-query", "/databases/database/query", "2022-06-28", func(ctx context.Context, c Client, st *store.Store) (int, error) {
+			return c.queryCollection(ctx, st, "database")
+		}},
+		{"query", "/data_sources/database/query", "2026-03-11", func(ctx context.Context, c Client, st *store.Store) (int, error) {
+			return c.queryCollection(ctx, st, "database")
+		}},
+		{"blocks", "/blocks/page/children", "2026-03-11", func(ctx context.Context, c Client, st *store.Store) (int, error) {
+			count, _, err := c.walkBlocks(ctx, st, "page", "page", "space")
+			return count, err
+		}},
+		{"comments", "/comments", "2026-03-11", func(ctx context.Context, c Client, st *store.Store) (int, error) {
+			return c.ingestComments(ctx, st, "page", "space")
+		}},
+	} {
+		for _, scenario := range []struct {
+			name      string
+			calls     int
+			wantError bool
+		}{
+			{"long", 125, false},
+			{"repeat", 2, true},
+			{"cycle", 3, true},
+			{"opaque", 2, false},
+		} {
+			t.Run(endpoint.name+"/"+scenario.name, func(t *testing.T) {
+				var calls atomic.Int32
+				next := ""
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					call := int(calls.Add(1))
+					if r.URL.Path != endpoint.path || call > scenario.calls {
+						http.Error(w, "unexpected pagination request", http.StatusInternalServerError)
+						return
+					}
+					cursor := r.URL.Query().Get("start_cursor")
+					if r.Method == http.MethodPost {
+						var body obj
+						if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+							t.Error(err)
+						}
+						cursor = body.string("start_cursor")
+					}
+					if cursor != next {
+						t.Errorf("cursor was altered: got %q, want %q", cursor, next)
+					}
+					next = fmt.Sprintf("cursor-%d", call)
+					switch scenario.name {
+					case "repeat":
+						next = "private-cursor-marker"
+					case "cycle":
+						next = fmt.Sprintf("private-cursor-marker-%d", call%2)
+					case "opaque":
+						next = " opaque +/% cursor "
+					}
+					item := obj{"id": fmt.Sprintf("item-%d", call), "name": "Fixture", "type": "paragraph", "properties": obj{}, "paragraph": obj{"rich_text": []any{obj{"plain_text": "Fixture"}}}, "rich_text": []any{obj{"plain_text": "Fixture"}}}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(obj{"results": []any{item}, "has_more": scenario.wantError || call < scenario.calls, "next_cursor": next})
+				}))
+				defer server.Close()
+				st, err := store.Open(filepath.Join(t.TempDir(), "archive.db"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer st.Close()
+				count, err := endpoint.run(context.Background(), Client{BaseURL: server.URL, Version: endpoint.version, Token: "test-token", HTTP: server.Client()}, st)
+				if scenario.wantError {
+					if err == nil || !strings.Contains(err.Error(), "repeated cursor") {
+						t.Fatalf("error = %v, want repeated cursor", err)
+					}
+				} else if err != nil || count != scenario.calls {
+					t.Fatalf("count = %d, error = %v; want %d items", count, err, scenario.calls)
+				}
+				if got := int(calls.Load()); got != scenario.calls {
+					t.Fatalf("requests = %d, want %d", got, scenario.calls)
+				}
+			})
+		}
+	}
+}
+
+func TestBlockPaginationFailurePreservesArchive(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.UpsertBlock(ctx, store.Block{ID: "existing", PageID: "page", ParentID: "page", Type: "paragraph", Text: "Keep existing content", Source: SourceName, Alive: true, SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetSyncState(ctx, SourceName, "page_blocks", "page", "complete"); err != nil {
+		t.Fatal(err)
+	}
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/users":
+			fmt.Fprint(w, `{"results":[]}`)
+		case "/search":
+			fmt.Fprint(w, `{"results":[{"id":"page","properties":{}}]}`)
+		case "/blocks/page/children":
+			if calls.Add(1) > 2 {
+				http.Error(w, "pagination did not stop", http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprint(w, `{"results":[{"id":"partial","type":"paragraph","paragraph":{"rich_text":[]}}],"has_more":true,"next_cursor":"private-cursor-marker"}`)
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	_, err = (Client{BaseURL: server.URL, Token: "test-token", HTTP: server.Client()}).Sync(ctx, st)
+	if err == nil || !strings.Contains(err.Error(), "repeated cursor") || calls.Load() != 2 {
+		t.Fatalf("sync error = %v; requests = %d", err, calls.Load())
+	}
+	if strings.Contains(err.Error(), "private-cursor-marker") {
+		t.Fatal("pagination error exposes an opaque cursor")
+	}
+	var alive int
+	if err := st.DB().QueryRowContext(ctx, `select alive from blocks where id = 'existing'`).Scan(&alive); err != nil || alive != 1 {
+		t.Fatalf("existing block was lost: alive=%d error=%v", alive, err)
+	}
+	if synced, err := st.HasSyncState(ctx, SourceName, "page_blocks", "page"); err != nil || synced {
+		t.Fatalf("partial page marked complete: synced=%v error=%v", synced, err)
+	}
+	if synced, err := st.HasSyncState(ctx, SourceName, "workspace", "default"); err != nil || synced {
+		t.Fatalf("failed workspace marked complete: synced=%v error=%v", synced, err)
+	}
+}
+
+func TestBlockPaginationCursorsAreScopedToEachParent(t *testing.T) {
+	var total atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		total.Add(1)
+		parent := strings.Split(r.URL.Path, "/")[2]
+		second := r.URL.Query().Get("start_cursor") != ""
+		id := parent + "-first"
+		if second {
+			id = parent + "-second"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(obj{
+			"results":  []any{obj{"id": id, "type": "paragraph", "has_children": parent == "page", "paragraph": obj{}}},
+			"has_more": !second, "next_cursor": "same-cursor-for-every-parent",
+		})
+	}))
+	defer server.Close()
+	st, err := store.Open(filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	count, _, err := (Client{BaseURL: server.URL, Token: "test-token", HTTP: server.Client()}).walkBlocks(context.Background(), st, "page", "page", "space")
+	if err != nil || count != 6 || total.Load() != 6 {
+		t.Fatalf("nested pagination: count=%d calls=%d error=%v", count, total.Load(), err)
+	}
+}


### PR DESCRIPTION
Reviewed integration of #102: REST pagination trusted every nonempty continuation cursor without cycle detection, so a repeated cursor looped forever. A per-listing cursor set stops immediate repeats and A→B→A cycles. Removes two regressions from the original PR: an added 100-page cap that rejected healthy longer listings, and cursor trimming that violates Notion's opaque-cursor contract. Cursor values are omitted from error text.

Proof: 15 built-CLI invocations, 746 local HTTP requests — 125-page user and block listings complete (failed at 100 with the original), repeat and cycle scenarios stop in 2–3 requests, opaque cursors preserved. 152 tests across 11 packages plus 33 focused checks and race testing; autoreview clean through P2. Credit to @SebTardif for the repeat-detection approach in #102. Fixes the repeated-cursor hang.