### PR TITLE
fix: bound GitHub release-check HTTP client

### DIFF
--- a/cmd/notcrawl/releasecheck.go
+++ b/cmd/notcrawl/releasecheck.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
+	"time"
 
 	"github.com/openclaw/crawlkit/releasecheck"
 	"github.com/openclaw/notcrawl/internal/config"
@@ -22,6 +24,7 @@ func notcrawlReleaseCheckOptions(force bool) releasecheck.Options {
 		CurrentVersion: version,
 		CacheDir:       cfg.CacheDir,
 		Force:          force,
+		Client:         &http.Client{Timeout: 5 * time.Second},
 	}
 }
 

--- a/cmd/notcrawl/releasecheck_test.go
+++ b/cmd/notcrawl/releasecheck_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNotcrawlReleaseCheckOptionsSetsHTTPClientTimeout(t *testing.T) {
+	opts := notcrawlReleaseCheckOptions(false)
+	if opts.Client == nil {
+		t.Fatal("Options.Client is nil; crawlkit would fall back to http.DefaultClient")
+	}
+	if opts.Client.Timeout != 5*time.Second {
+		t.Fatalf("Options.Client.Timeout = %v, want 5s", opts.Client.Timeout)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`notcrawl` release-check never passed an HTTP client into crawlkit. A stalled GitHub Releases TCP session then used `http.DefaultClient` (no timeout) and hung the CLI notify path forever.

## Why

`notcrawlReleaseCheckOptions` built `releasecheck.Options` with version, cache, and force, but left `Client` nil. crawlkit falls back to `http.DefaultClient` in that case. Release-check is a finite JSON GET, not a stream, so a 5s client timeout is the right bound.

This path has been unbounded since [`f0134e89`](https://github.com/openclaw/notcrawl/commit/f0134e89) (2026-05-17).

## User Impact

A hung GitHub Releases endpoint (or a blackholed route) can pin `notcrawl` during the background version notify instead of failing in a few seconds.

## Evidence

Live `go run` against a TCP listener that never accepts. Same `http.Client{Timeout: 5s}` the patch now injects. The call returned in 5.002s instead of hanging:

```console
$ go run /tmp/sibling-proof/nc-release-client.go
elapsed=5.002s err=Get "http://127.0.0.1:54099/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
host_listen_seconds=5.4 (never accepted; client returned)
```

## Real behavior proof

- **Behavior or issue addressed:** Release-check used crawlkit's DefaultClient fallback, so a stalled GitHub Releases host hung the notify path.
- **Real environment tested:** macOS, Go 1.25, worktree `/tmp/nc-release-timeout` at `af33f56`, live `go run` against a local never-accept TCP listener.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/sibling-proof/nc-release-client.go
  ```

- **Evidence after fix:** terminal output from the live client:

  ```console
  $ go run /tmp/sibling-proof/nc-release-client.go
  elapsed=5.002s err=Get "http://127.0.0.1:54099/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  host_listen_seconds=5.4 (never accepted; client returned)
  ```

- **Observed result after fix:** The 5s client returns `Client.Timeout exceeded while awaiting headers` against a host that never accepts. The CLI notify path can fail closed instead of blocking forever.
- **What was not tested:** Live github.com/repos/openclaw/notcrawl/releases/latest from this machine.

## Change

- `cmd/notcrawl/releasecheck.go`: set `Client: &http.Client{Timeout: 5 * time.Second}`
- `cmd/notcrawl/releasecheck_test.go`: assert the options client is non-nil and 5s
