### PR TITLE
fix: cap Notion Retry-After waits

### DIFF
--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -21,6 +21,10 @@ const SourceName = "api"
 
 const maxAPIAttempts = 4
 
+// maxRetryAfter caps Retry-After waits. Notion may send delta-seconds or an
+// HTTP-date far in the future; CLI contexts often have no deadline.
+const maxRetryAfter = 60 * time.Second
+
 // defaultHTTPTimeout bounds Notion API requests when Client.HTTP is nil.
 // Callers may inject a custom client, including one with no overall timeout.
 const defaultHTTPTimeout = 60 * time.Second
@@ -757,23 +761,28 @@ func isReplaySafeRequest(method, path string) bool {
 }
 
 func retryAfter(header string, body []byte) time.Duration {
+	var wait time.Duration
 	if header != "" {
 		if seconds, err := time.ParseDuration(header + "s"); err == nil && seconds > 0 {
-			return seconds
-		}
-		if when, err := http.ParseTime(header); err == nil {
-			if wait := time.Until(when); wait > 0 {
-				return wait
+			wait = seconds
+		} else if when, err := http.ParseTime(header); err == nil {
+			if until := time.Until(when); until > 0 {
+				wait = until
 			}
 		}
 	}
-	var payload struct {
-		RetryAfter float64 `json:"retry_after"`
+	if wait == 0 {
+		var payload struct {
+			RetryAfter float64 `json:"retry_after"`
+		}
+		if err := json.Unmarshal(body, &payload); err == nil && payload.RetryAfter > 0 {
+			wait = time.Duration(payload.RetryAfter * float64(time.Second))
+		}
 	}
-	if err := json.Unmarshal(body, &payload); err == nil && payload.RetryAfter > 0 {
-		return time.Duration(payload.RetryAfter * float64(time.Second))
+	if wait > maxRetryAfter {
+		return maxRetryAfter
 	}
-	return 0
+	return wait
 }
 
 func waitBeforeRetry(ctx context.Context, wait time.Duration) error {

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -1067,6 +1067,21 @@ func TestNextListCursorRejectsRepeatedAndEmpty(t *testing.T) {
 	}
 }
 
+func TestRetryAfterCapsDeltaSeconds(t *testing.T) {
+	got := retryAfter("86400", nil)
+	if got != 60*time.Second {
+		t.Fatalf("retryAfter(86400) = %s, want 60s", got)
+	}
+}
+
+func TestRetryAfterCapsHTTPDate(t *testing.T) {
+	when := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
+	got := retryAfter(when, nil)
+	if got != 60*time.Second {
+		t.Fatalf("retryAfter(%q) = %s, want 60s", when, got)
+	}
+}
+
 type repeatingListCursorPager struct {
 	cursor string
 	calls  int


### PR DESCRIPTION
## What Problem This Solves

`retryAfter` honored Notion `Retry-After` delta-seconds and HTTP-dates with no upper bound. A 86400s header, or a date a day in the future, parked `notcrawl sync` for hours even when the CLI had no deadline.

## Why

The helper returned the parsed wait as-is. Notion may send either delta-seconds or an HTTP-date. Official list loops then `waitBeforeRetry` that full duration. Request timeouts (#91) do not cap this sleep.

This parser has been uncapped since [`2dcf13a4`](https://github.com/openclaw/notcrawl/commit/2dcf13a4) (2026-04-29).

## User Impact

A single oversized `Retry-After` can stall `notcrawl sync` for a day. After this change the wait is at most 60s per attempt (still up to `maxAPIAttempts`).

## Evidence

Live `go run` of the same parse-and-cap logic:

```console
$ go run /tmp/sibling-proof/nc-retry-live.go
retryAfter(86400)=1m0s
retryAfter(HTTP-date +24h)=1m0s
retryAfter(5)=5s
```

## Real behavior proof

- **Behavior or issue addressed:** Uncapped Retry-After (delta-seconds or HTTP-date) could sleep the Notion client for hours.
- **Real environment tested:** macOS, Go 1.25, worktree `/tmp/nc-retry-after-cap` at `aa49484`, live `go run` of the parse-and-cap helper.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/sibling-proof/nc-retry-live.go
  ```

- **Evidence after fix:** terminal output from the live helper:

  ```console
  $ go run /tmp/sibling-proof/nc-retry-live.go
  retryAfter(86400)=1m0s
  retryAfter(HTTP-date +24h)=1m0s
  retryAfter(5)=5s
  ```

- **Observed result after fix:** A 86400s header and a +24h HTTP-date both cap at 60s. A 5s header still waits 5s.
- **What was not tested:** A live Notion 429 with a real oversized Retry-After header.

## Change

- `internal/notionapi/api.go`: `maxRetryAfter = 60s`; cap delta-seconds, HTTP-date, and JSON `retry_after`
- `internal/notionapi/api_test.go`: cover 86400s and a +24h HTTP-date
