### PR TITLE
fix(share): return gzip and file close errors on publish

### DIFF
--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -462,27 +463,45 @@ func importAtRef(ctx context.Context, st *store.Store, opts mirror.Options, ref 
 	return imported, commit, err
 }
 
+var createExportFile = func(name string) (io.WriteCloser, error) {
+	return os.Create(name)
+}
+
 func exportTable(ctx context.Context, db *sql.DB, repoPath, table string) (TableManifest, error) {
 	path := filepath.ToSlash(filepath.Join("data", table+".jsonl.gz"))
 	full := filepath.Join(repoPath, path)
-	out, err := os.Create(full)
+	out, err := createExportFile(full)
 	if err != nil {
 		return TableManifest{}, err
 	}
-	defer out.Close()
 	gz := gzip.NewWriter(out)
-	defer gz.Close()
+	count, exportErr := encodeExportRows(ctx, db, table, gz)
+	gzErr := gz.Close()
+	fileErr := out.Close()
+	if exportErr != nil {
+		return TableManifest{}, exportErr
+	}
+	if gzErr != nil {
+		return TableManifest{}, gzErr
+	}
+	if fileErr != nil {
+		return TableManifest{}, fileErr
+	}
+	return TableManifest{Name: table, Path: path, Rows: count}, nil
+}
+
+func encodeExportRows(ctx context.Context, db *sql.DB, table string, w io.Writer) (int, error) {
 	rows, err := db.QueryContext(ctx, "select * from "+quoteIdent(table))
 	if err != nil {
-		return TableManifest{}, err
+		return 0, err
 	}
 	defer rows.Close()
 	cols, err := rows.Columns()
 	if err != nil {
-		return TableManifest{}, err
+		return 0, err
 	}
 	count := 0
-	enc := json.NewEncoder(gz)
+	enc := json.NewEncoder(w)
 	for rows.Next() {
 		values := make([]any, len(cols))
 		ptrs := make([]any, len(cols))
@@ -490,21 +509,21 @@ func exportTable(ctx context.Context, db *sql.DB, repoPath, table string) (Table
 			ptrs[i] = &values[i]
 		}
 		if err := rows.Scan(ptrs...); err != nil {
-			return TableManifest{}, err
+			return 0, err
 		}
 		row := map[string]any{}
 		for i, col := range cols {
 			row[col] = exportValue(values[i])
 		}
 		if err := enc.Encode(row); err != nil {
-			return TableManifest{}, err
+			return 0, err
 		}
 		count++
 	}
 	if err := rows.Err(); err != nil {
-		return TableManifest{}, err
+		return 0, err
 	}
-	return TableManifest{Name: table, Path: path, Rows: count}, nil
+	return count, nil
 }
 
 type sqlExecer interface {

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -3,6 +3,8 @@ package share
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -682,6 +684,83 @@ func TestPublishValidatesTagBeforeRemoteSync(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "invalid snapshot tag") {
 		t.Fatalf("Publish error = %v", err)
+	}
+}
+
+type failOnCloseWriter struct {
+	io.WriteCloser
+	closeErr error
+}
+
+func (w failOnCloseWriter) Close() error {
+	_ = w.WriteCloser.Close()
+	return w.closeErr
+}
+
+type failOnWriteCloser struct {
+	io.WriteCloser
+	writeErr error
+}
+
+func (w failOnWriteCloser) Write([]byte) (int, error) {
+	return 0, w.writeErr
+}
+
+func TestPublishReturnsExportCloseErrorWithoutCommitting(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		wrap func(io.WriteCloser, error) io.WriteCloser
+	}{
+		{"file close", errors.New("disk full"), func(inner io.WriteCloser, err error) io.WriteCloser {
+			return failOnCloseWriter{WriteCloser: inner, closeErr: err}
+		}},
+		{"gzip close", errors.New("gzip footer flush"), func(inner io.WriteCloser, err error) io.WriteCloser {
+			return failOnWriteCloser{WriteCloser: inner, writeErr: err}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := filepath.Join(t.TempDir(), "repo")
+			if err := os.MkdirAll(repo, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			runGitForTest(t, repo, "init", "-b", "main")
+			runGitForTest(t, repo,
+				"-c", "commit.gpgsign=false",
+				"-c", "user.name=test",
+				"-c", "user.email=test@example.invalid",
+				"commit", "--allow-empty", "-m", "seed",
+			)
+			src, mdDir := snapshotStoreForTest(t, ctx, "Launch", "hello")
+			defer src.Close()
+
+			orig := createExportFile
+			t.Cleanup(func() { createExportFile = orig })
+			createExportFile = func(name string) (io.WriteCloser, error) {
+				f, err := os.Create(name)
+				if err != nil {
+					return nil, err
+				}
+				return tc.wrap(f, tc.err), nil
+			}
+
+			s, err := Publish(ctx, src, PublishOptions{RepoPath: repo, MarkdownDir: mdDir, Commit: true})
+			if err == nil {
+				t.Fatal("expected export close error")
+			}
+			if !errors.Is(err, tc.err) && !strings.Contains(err.Error(), tc.err.Error()) {
+				t.Fatalf("Publish error = %v", err)
+			}
+			if s.Committed {
+				t.Fatal("snapshot must not be committed after export close error")
+			}
+			log := gitOutputForTest(t, repo, "log", "--format=%s")
+			if strings.Contains(log, "archive: notcrawl snapshot") {
+				t.Fatalf("unexpected snapshot commit:\n%s", log)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

`notcrawl publish` writes each share table to `data/<table>.jsonl.gz`. `exportTable` used `defer gz.Close()` and `defer out.Close()`. `gzip.Writer.Close` flushes compressed bytes and writes the 8-byte gzip footer (CRC32 and size). A disk-full or flush error from that Close (or from the file Close) was discarded, so Publish still built the manifest and committed the snapshot. Downstream `notcrawl subscribe` / `update` then imported a truncated archive as if it were complete.

## Why

The Go gzip writer does not finish the stream on `Write`. Close is the call that writes the footer. The same class was fixed in the Go tree itself in [golang/go#79424](https://github.com/golang/go/pull/79424) (`internal/profile`: return `gzip.Writer.Close` instead of deferring it). This repo already checks the writable-file close on `export-db --all`. Publish should do the same before it treats the snapshot as ready to commit.

This path has been unbounded since [`a73fd87`](https://github.com/openclaw/notcrawl/commit/a73fd87) (2026-04-22, git snapshot sharing) and remained after [#51](https://github.com/openclaw/notcrawl/pull/51).

## User Impact

A full disk, quota, or NFS flush error during publish can leave a committed share repo whose `.jsonl.gz` files are missing the gzip footer. Importers then see unexpected EOF or a short table instead of a failed publish.

## Evidence

Live `go run` of the old defer-close pattern versus checked close. Same `failClose` writer (writes succeed, Close returns `disk full`). The old pattern reports success after writing 40 compressed bytes. Checked close returns `disk full`. `gzip.Writer.Close` on a writer that fails `Write` also returns `disk full` (footer path):

```console
$ go run /tmp/f005-gzip-close-proof.go
old_defer close_err=<nil> wrote=40
checked_close close_err=disk full wrote=40
gzip_close_on_failed_writer err=disk full
```

After the patch, live `notcrawl publish --no-commit` still writes a readable archive. `gzip -t` accepts `pages.jsonl.gz`, and the inserted page is present:

```console
$ /tmp/notcrawl-f005 --config /tmp/f005-publish-EUIE8T/notcrawl.toml --db /tmp/f005-publish-EUIE8T/notcrawl.db publish --repo /tmp/f005-publish-EUIE8T/share --no-commit
published 9 tables to /tmp/f005-publish-EUIE8T/share committed=false pushed=false
$ gzip -t /tmp/f005-publish-EUIE8T/share/data/pages.jsonl.gz
gzip_pages=ok
page_row page1 Launch
page_rows 1
```

## Real behavior proof

- **Behavior or issue addressed:** Publish discarded gzip and file Close errors, then committed a snapshot whose `.jsonl.gz` files can miss the gzip footer.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go 1.27.0, worktree `/tmp/oc-pr-notcrawl-F005` on `fix/f005-publish-gzip-close`, live `go run` and `notcrawl publish`.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/f005-gzip-close-proof.go
  /tmp/notcrawl-f005 --config /tmp/f005-publish-EUIE8T/notcrawl.toml --db /tmp/f005-publish-EUIE8T/notcrawl.db publish --repo /tmp/f005-publish-EUIE8T/share --no-commit
  gzip -t /tmp/f005-publish-EUIE8T/share/data/pages.jsonl.gz
  ```

- **Evidence after fix:** terminal output from the live close demo and publish:

  ```console
  $ go run /tmp/f005-gzip-close-proof.go
  old_defer close_err=<nil> wrote=40
  checked_close close_err=disk full wrote=40
  gzip_close_on_failed_writer err=disk full
  $ /tmp/notcrawl-f005 publish --repo /tmp/f005-publish-EUIE8T/share --no-commit
  published 9 tables to /tmp/f005-publish-EUIE8T/share committed=false pushed=false
  gzip_pages=ok
  page_row page1 Launch
  ```

- **Observed result after fix:** Checked close returns `disk full` instead of success. Live publish writes a gzip file that `gzip -t` accepts and that decodes the inserted `page1` / `Launch` row.
- **What was not tested:** A real ENOSPC on a full physical volume, and a push of the share remote.

## Change

- `internal/share/share.go`: close the gzip writer, then the file, and return those errors before building the table manifest
- `internal/share/share_test.go`: Publish with `Commit: true` returns a gzip or file close error and does not create the snapshot commit
