### PR TITLE
fix: return export-db --output file close errors

### DIFF
--- a/cmd/notcrawl/main.go
+++ b/cmd/notcrawl/main.go
@@ -652,6 +652,10 @@ func runDatabases(ctx context.Context, stdout io.Writer, cfg config.Config) erro
 	return nil
 }
 
+var createExportOutput = func(name string) (io.WriteCloser, error) {
+	return os.Create(name)
+}
+
 func runExportDatabase(ctx context.Context, stdout io.Writer, cfg config.Config, args []string) error {
 	fs := flag.NewFlagSet("export-db", flag.ContinueOnError)
 	databaseID := fs.String("database", "", "database id to export")
@@ -687,27 +691,33 @@ func runExportDatabase(ctx context.Context, stdout io.Writer, cfg config.Config,
 	}
 	defer st.Close()
 	var out io.Writer = stdout
-	var file *os.File
+	var file io.WriteCloser
+	outputName := ""
 	if *output != "" {
 		outputPath, err := config.ExpandPath(*output)
 		if err != nil {
 			return err
 		}
-		file, err = os.Create(outputPath)
+		file, err = createExportOutput(outputPath)
 		if err != nil {
 			return err
 		}
-		defer file.Close()
 		out = file
+		outputName = outputPath
 	}
-	s, err := tableexport.Exporter{Store: st}.Export(ctx, *databaseID, formatValue, out)
-	if err != nil {
-		return err
+	s, exportErr := tableexport.Exporter{Store: st}.Export(ctx, *databaseID, formatValue, out)
+	if file != nil {
+		closeErr := file.Close()
+		if exportErr != nil {
+			return exportErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		fmt.Fprintf(stdout, "exported %d rows and %d columns from %s to %s\n", s.Rows, s.Columns, s.Database, outputName)
+		return nil
 	}
-	if *output != "" {
-		fmt.Fprintf(stdout, "exported %d rows and %d columns from %s to %s\n", s.Rows, s.Columns, s.Database, file.Name())
-	}
-	return nil
+	return exportErr
 }
 
 func runExportAllDatabases(ctx context.Context, stdout io.Writer, cfg config.Config, format tableexport.Format, dir string) error {

--- a/cmd/notcrawl/main_test.go
+++ b/cmd/notcrawl/main_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -655,6 +656,62 @@ func TestExportDatabaseAllWritesFilesAndIndex(t *testing.T) {
 	}
 	if row := rowsByID["db2"]; row[1] != "Launch 🚀 Plan ✅\tQ3\nReview" || row[5] != "launch-plan-q3-review-db2.csv" {
 		t.Fatalf("escaped collection name did not round-trip: %#v", row)
+	}
+}
+
+type failOnCloseWriter struct {
+	io.WriteCloser
+	closeErr error
+}
+
+func (w failOnCloseWriter) Close() error {
+	_ = w.WriteCloser.Close()
+	return w.closeErr
+}
+
+func TestExportDatabaseOutputReturnsCloseError(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "notcrawl.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := store.NowMS()
+	if err := st.UpsertCollection(ctx, store.Collection{
+		ID: "db1", Name: "Roadmap", Source: "test", SyncedAt: now, SchemaJSON: `{"Name":{"type":"title"}}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPage(ctx, store.Page{
+		ID: "page1", CollectionID: "db1", Title: "Ship", URL: "https://example.com/ship", Alive: true, Source: "test", SyncedAt: now,
+		PropertiesJSON: `{"Name":{"type":"title","title":[{"plain_text":"Ship"}]}}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := errors.New("disk full")
+	orig := createExportOutput
+	t.Cleanup(func() { createExportOutput = orig })
+	createExportOutput = func(name string) (io.WriteCloser, error) {
+		f, err := os.Create(name)
+		if err != nil {
+			return nil, err
+		}
+		return failOnCloseWriter{WriteCloser: f, closeErr: want}, nil
+	}
+
+	outputPath := filepath.Join(dir, "roadmap.csv")
+	var stdout, stderr bytes.Buffer
+	err = run(ctx, []string{"--config", filepath.Join(dir, "missing.toml"), "--db", dbPath, "export-db", "--database", "db1", "--output", outputPath}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected export-db --output close error")
+	}
+	if !errors.Is(err, want) && !strings.Contains(err.Error(), want.Error()) {
+		t.Fatalf("export-db --output error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

`notcrawl export-db --output FILE` wrote the CSV or TSV, then used `defer file.Close()`. Close is the call that flushes the last bytes to disk. A disk-full, quota, or NFS flush error from that Close was discarded, so the command still printed `exported N rows ... to FILE` and exited 0.

## Why

The sibling `export-db --all` path already checks `closeErr` after each file write ([#22](https://github.com/openclaw/notcrawl/pull/22)). `--output` was added earlier in [#1](https://github.com/openclaw/notcrawl/pull/1) and never got the same check. Writable-file Close is the same class as [golang/go#79424](https://github.com/golang/go/pull/79424) and the publish path in [#112](https://github.com/openclaw/notcrawl/pull/112).

This path has been unbounded since [`0a1d9b19`](https://github.com/openclaw/notcrawl/commit/0a1d9b19927bfa58349bc11fa4d7d364465b088f) (2026-04-22).

## User Impact

A full disk or flush error during `export-db --output` can leave a short or unflushed file while the CLI reports success. Scripts that treat a 0 exit as a complete export then consume a truncated CSV or TSV.

## Evidence

Live `go run` of the old defer-close pattern versus checked close. Same `failClose` writer (writes succeed, Close returns `disk full`). The old pattern reports success after writing 10 bytes. Checked close returns `disk full`:

```console
$ go run /tmp/f006-export-close-proof.go
old_defer close_err=<nil> wrote=10
checked_close close_err=disk full wrote=10
```

After the patch, live `notcrawl export-db --output` still writes a readable CSV. The seeded Roadmap row is present:

```console
$ /tmp/notcrawl-f006 --config /tmp/f006-export-6mKWal/notcrawl.toml --db /tmp/f006-export-6mKWal/notcrawl.db export-db --database db1 --format csv --output /tmp/f006-export-6mKWal/roadmap.csv
exported 1 rows and 4 columns from db1 to /tmp/f006-export-6mKWal/roadmap.csv
$ cat /tmp/f006-export-6mKWal/roadmap.csv
page_id,page_title,url,Name
page1,Ship,https://example.com/ship,Ship
```

## Real behavior proof

- **Behavior or issue addressed:** `export-db --output FILE` discarded the writable file Close error and reported a successful export.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Go 1.27.0, worktree `/tmp/oc-pr-notcrawl-F006` on `fix/f006-export-db-close`, live `go run` and `notcrawl export-db`.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/f006-export-close-proof.go
  /tmp/notcrawl-f006 --config /tmp/f006-export-6mKWal/notcrawl.toml --db /tmp/f006-export-6mKWal/notcrawl.db export-db --database db1 --format csv --output /tmp/f006-export-6mKWal/roadmap.csv
  cat /tmp/f006-export-6mKWal/roadmap.csv
  ```

- **Evidence after fix:** terminal output from the live close demo and export:

  ```console
  $ go run /tmp/f006-export-close-proof.go
  old_defer close_err=<nil> wrote=10
  checked_close close_err=disk full wrote=10
  $ /tmp/notcrawl-f006 export-db --database db1 --format csv --output /tmp/f006-export-6mKWal/roadmap.csv
  exported 1 rows and 4 columns from db1 to /tmp/f006-export-6mKWal/roadmap.csv
  page_id,page_title,url,Name
  page1,Ship,https://example.com/ship,Ship
  ```

- **Observed result after fix:** Checked close returns `disk full` instead of success. Live `export-db --output` writes a CSV that contains the seeded `page1` / `Ship` row.
- **What was not tested:** A real ENOSPC on a full physical volume, and TSV output on this same close path.

## Change

- `cmd/notcrawl/main.go`: close the `--output` file explicitly and return the close error, matching `--all`
- `cmd/notcrawl/main_test.go`: `export-db --output` returns a file close error
