### PR TITLE
chore(deps): update CrawlKit to v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Dependencies
 
+- Update CrawlKit to v0.14.8 so release checks time out after 30 seconds instead of hanging on an unresponsive server.
 - Update Go to 1.27.0, SQLite to v1.57.0, indirect Go modules, vulnerability and dead-code tooling, and the stale and secret-scanning GitHub Actions.
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.0
 
 require (
 	github.com/alecthomas/kong v1.16.1
-	github.com/openclaw/crawlkit v0.14.7
+	github.com/openclaw/crawlkit v0.14.8
 	modernc.org/sqlite v1.57.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+ArQ=
-github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
+github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
+github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
CrawlKit v0.14.8 gives Notcrawl's default release-check HTTP client a 30-second timeout. A stalled release server can no longer hold `check-update` or passive update notifications indefinitely. Adopt the upstream fix and document the user-visible behavior in the changelog.

## Dependency audit

- `github.com/openclaw/crawlkit`: **v0.14.7 → v0.14.8** ([release notes](https://github.com/openclaw/crawlkit/releases/tag/v0.14.8)); `go.sum` regenerated with Go.
- Ran `GOWORK=off go get -u -t ./...` and `GOWORK=off go mod tidy`. No other project build/test dependency needed changing. No dependencies added or removed.
- Go **1.27.0**, Kong **v1.16.1**, SQLite **v1.57.0**, govulncheck **v1.7.0**, and deadcode **v0.49.0** are current. Checked every workflow action against its upstream release/tag; floating major references and immutable pins already cover the current releases.
- Remaining updates in `go list -m -u all` belong to unused upstream modules or upstream-only tests (`pprof` through SQLite tests and `x/mod` through libc tests). They are outside Notcrawl's build/test package closure; adding explicit requirements solely to override them would add dependencies.
- No majors taken. Charm v2 (Bubble Tea v2.0.9, Bubbles v2.2.1, Lip Gloss v2.0.6) changes module paths and rendering/input APIs. CrawlKit owns those imports and its TUI implementation. Recommendation: migrate them together in CrawlKit, release it, then update Notcrawl; do not fork or replace CrawlKit in this dependency refresh. See the [upstream migration guide](https://github.com/charmbracelet/bubbletea/blob/main/UPGRADE_GUIDE_V2.md).

## Live proof

Ran the newly built binary against a real SQLite file containing two synthetic Notion Desktop records: a page titled `Dependency smoke` and a child block containing `Fresh archive search works.` No private workspace data or credentials were used. The full driver also asserted the exported Markdown body and unchanged source SHA-256, then exercised the terminal UI in a PTY.

Build and driver commands:

```sh
GOWORK=off GOCACHE="$PWD/.git/deps-refresh-20260830/go-cache" go build -ldflags '-X main.version=0.5.8' -o .git/deps-refresh-20260830/notcrawl-live ./cmd/notcrawl
python3 .git/deps-refresh-20260830/live-proof.py
```

Actual command/output excerpts (`NOTCRAWL_NO_UPDATE_CHECK=1` for archive operations):

```console
$ .git/deps-refresh-20260830/notcrawl-live --config .git/deps-refresh-20260830/fixture/config.toml sync --source desktop
desktop: pages=1 blocks=2 teams=0 collections=0 comments=0 snapshot=/Users/steipete/Projects/notcrawl/.git/deps-refresh-20260830/fixture/cache/notion-desktop-1788161533075.db
$ .git/deps-refresh-20260830/notcrawl-live --config .git/deps-refresh-20260830/fixture/config.toml search Fresh
page	page1	Dependency smoke	[Fresh] archive search works.
$ .git/deps-refresh-20260830/notcrawl-live --config .git/deps-refresh-20260830/fixture/config.toml export-md
exported 1 pages to /Users/steipete/Projects/notcrawl/.git/deps-refresh-20260830/fixture/pages
Markdown body: Fresh archive search works.
Source SQLite SHA-256 unchanged: true
$ .git/deps-refresh-20260830/notcrawl-live --config .git/deps-refresh-20260830/fixture/config.toml sql 'SELECT count(*) AS pages FROM pages'
pages
1
$ .git/deps-refresh-20260830/notcrawl-live --config .git/deps-refresh-20260830/fixture/config.toml tui
TUI rendered archived page and exited on q: exit=0
```

For the changed behavior, a loopback HTTP proxy accepted the real binary's CONNECT request and deliberately withheld its response. This exercised the default release-check client without contacting GitHub or changing release-check cache files:

```console
$ HTTPS_PROXY=http://127.0.0.1:62433 NO_PROXY= .git/deps-refresh-20260830/notcrawl-live check-update --force --json
Local proxy received CONNECT api.github.com:443; deliberately withholding response.
notcrawl: check latest openclaw/notcrawl release: Get "https://api.github.com/repos/openclaw/notcrawl/releases/latest": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
elapsed=30.019s exit=1
Live proof passed.
```

Exit 1 is the expected bounded network failure; the live driver asserted this result and exited 0.

## CI reasoning and validation

Default-branch build/test CI was already green at `c63b53a`: [CI run 33188914166](https://github.com/openclaw/notcrawl/actions/runs/33188914166). No CI assertions, tests, jobs, or workflow permissions are changed.

CodeQL and verified-secret scanning are security gates. Stale is scheduled issue/PR maintenance; ClawSweeper Dispatch, Auto Assign, and Release Drafter are operational workflows. The unified release workflow is manual publication and was not dispatched. A successful maintenance/dispatch run is not counted as build/test proof.

Codex Autoreview completed with `scoped-clean`, exit 0, and no findings at its default P0 threshold.

Maintainer follow-up: #110 proposes a Notcrawl-specific five-second client for the same previously unbounded path. This update fixes that bug at its shared owner with a thirty-second default. Review whether a stricter Notcrawl-specific deadline is still wanted; this PR does not close or modify #110.

The complete local gate passed with Go 1.27.0 and GoReleaser 2.18.0:

```sh
GOWORK=off GOCACHE="$PWD/.git/deps-refresh-20260830/go-cache" make check BINARY=.git/deps-refresh-20260830/notcrawl
```

This covered module verification/tidy, govulncheck, formatting, vet, deadcode, all 11 Go test packages, release-script tests, CLI smoke, both GoReleaser config checks, and both credential-free snapshot builds. Actual output excerpts:

```text
all modules verified
No vulnerabilities found.
ok  	github.com/openclaw/notcrawl/cmd/notcrawl	75.720s
ok  	github.com/openclaw/notcrawl/internal/share	317.627s
ok  	github.com/openclaw/notcrawl/internal/store	131.614s
release script tests passed
  • release succeeded after 2m29s
  • release succeeded after 43s
make check exit: 0
```

PR build/test [CI run 33369449367](https://github.com/openclaw/notcrawl/actions/runs/33369449367) passed all five jobs: deps, lint, Linux test/build/smoke, Windows test/build, and snapshot release-check. [CodeQL](https://github.com/openclaw/notcrawl/actions/runs/33369449353) and [verified-secret scanning](https://github.com/openclaw/notcrawl/actions/runs/33369449388) also passed. No retries or CI fixes were needed; default-branch code remains unchanged and green. Nothing was published or released.
