### PR TITLE
docs(changelog): credit release-check timeout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Bound the release-check HTTP client to a 5-second timeout so a stalled GitHub Releases host cannot pin the
+  background version notify. Thanks @SebTardif.
 - Reject repeated official API cursors without limiting healthy pagination or rewriting opaque cursor values. Thanks @SebTardif.
 - Reject repeated Notion MCP `tools/list` cursors and cap discovery at 100 pages so a malformed pager cannot livelock sync.
 


### PR DESCRIPTION
Changelog entry for #110, which bounded the release-check HTTP client to 5s. Credit to @SebTardif per house convention (contributor PRs don't carry the changelog edit; the maintainer adds it on merge).