### PR TITLE
fix(sql): keep notcrawl sql read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Enforce read-only SQL access without rejecting valid CTEs, quoted punctuation, or comments; leave archive creation and upgrades to sync. Thanks @SebTardif.
 - Return gzip and output-file finalization errors before committing Git share snapshots. Thanks @SebTardif.
 - Return output-file close errors before reporting successful CSV/TSV database exports. Thanks @SebTardif.
 - Bound the release-check HTTP client to a 5-second timeout so a stalled GitHub Releases host cannot pin the

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The main commands are:
 
 Run `notcrawl --help` for the full command summary.
 
+`sql` accepts one SELECT, WITH, or PRAGMA statement and opens the archive read-only. Quoted punctuation and SQL comments are supported. It never creates or migrates the archive; run `sync` first to prepare a new archive or upgrade an older schema.
+
 ## Share an archive
 
 Git share mode publishes compressed JSONL table snapshots and normalized Markdown. Another machine can subscribe and search the archive without Notion credentials.

--- a/SPEC.md
+++ b/SPEC.md
@@ -108,6 +108,8 @@ for common page, collection, comment, raw-record, and sync-state lookups.
 `report` must provide a SQL-free archive summary: total records, recent edited
 page/comment windows, top databases, top spaces, and recently edited pages.
 
+`sql` opens an existing archive read-only, without creating tables or migrating its schema. SQLite enforces write rejection; the CLI accepts only one SELECT, WITH, or PRAGMA statement so input cannot disable connection safeguards and execute further statements. Quoted strings, identifiers, and comments retain SQLite syntax. Run `sync` to initialize or upgrade an archive before querying newer fields.
+
 Core tables:
 
 - `spaces`

--- a/cmd/notcrawl/main.go
+++ b/cmd/notcrawl/main.go
@@ -1309,12 +1309,12 @@ func runSQL(ctx context.Context, stdout io.Writer, cfg config.Config, args []str
 		return fmt.Errorf("sql query required")
 	}
 	query := strings.TrimSpace(strings.Join(parsed.Query, " "))
-	if !isReadOnlyQuery(query) {
+	if !isSQLInspectionQuery(query) {
 		return fmt.Errorf("only read-only select/with/pragma queries are allowed")
 	}
 	st, err := store.OpenReadOnly(cfg.DBPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("open archive for read-only SQL (run sync first to create or upgrade an archive): %w", err)
 	}
 	defer st.Close()
 	rows, err := st.DB().QueryContext(ctx, query)
@@ -1538,67 +1538,65 @@ Writes a starter TOML config to --config or the standard notcrawl config path.
 `)
 }
 
-func isReadOnlyQuery(query string) bool {
+func isSQLInspectionQuery(query string) bool {
 	lower := strings.ToLower(strings.TrimSpace(query))
-	for strings.HasSuffix(lower, ";") {
-		lower = strings.TrimSpace(strings.TrimSuffix(lower, ";"))
-	}
-	if lower == "" || strings.Contains(lower, ";") {
+	if !strings.HasPrefix(lower, "select ") && !strings.HasPrefix(lower, "with ") && !strings.HasPrefix(lower, "pragma ") {
 		return false
 	}
-	switch {
-	case strings.HasPrefix(lower, "select "):
-		return true
-	case strings.HasPrefix(lower, "with "):
-		return withSelectsOnly(lower)
-	case strings.HasPrefix(lower, "pragma "):
-		return isReadOnlyPragma(lower)
-	default:
-		return false
-	}
-}
-
-func isReadOnlyPragma(lower string) bool {
-	if strings.Contains(lower, "=") {
-		return false
-	}
-	body := strings.TrimSpace(strings.TrimPrefix(lower, "pragma"))
-	name := body
-	if i := strings.IndexAny(body, " ("); i >= 0 {
-		name = body[:i]
-	}
-	switch strings.TrimSpace(name) {
-	case "", "optimize", "incremental_vacuum", "wal_checkpoint":
-		return false
-	default:
-		return true
-	}
-}
-
-func withSelectsOnly(lower string) bool {
-	depth := 0
-	seenParen := false
-	for i := 0; i < len(lower); i++ {
-		switch lower[i] {
-		case '(':
-			depth++
-			seenParen = true
-		case ')':
-			if depth == 0 {
-				return false
+	// SQLite's mode=ro enforces archive safety. Limit input to one statement so
+	// it cannot disable query_only and then attach a writable database.
+	ended := false
+	for i := 0; i < len(query); i++ {
+		switch query[i] {
+		case 0:
+			return false
+		case ' ', '\t', '\r', '\n', '\f':
+			continue
+		case ';':
+			ended = true
+			continue
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				for i < len(query) && query[i] != '\n' {
+					i++
+				}
+				continue
 			}
-			depth--
-			if seenParen && depth == 0 {
-				rest := strings.TrimSpace(lower[i+1:])
-				if strings.HasPrefix(rest, ",") {
-					seenParen = false
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				end := strings.Index(query[i+2:], "*/")
+				if end < 0 {
+					return true // SQLite treats an unfinished block comment as EOF.
+				}
+				i += end + 3
+				continue
+			}
+		}
+		if ended {
+			return false
+		}
+		switch quote := query[i]; quote {
+		case '\'', '"', '`', '[':
+			closing := quote
+			if quote == '[' {
+				closing = ']'
+			}
+			for i++; ; i++ {
+				if i >= len(query) {
+					return false
+				}
+				if query[i] != closing {
 					continue
 				}
-				return strings.HasPrefix(rest, "select ") || strings.HasPrefix(rest, "select(")
+				if quote != '[' && i+1 < len(query) && query[i+1] == closing {
+					i++
+					continue
+				}
+				break
 			}
 		}
 	}
-	return false
+	return true
 }
 
 func printHelp(w io.Writer) {

--- a/cmd/notcrawl/main.go
+++ b/cmd/notcrawl/main.go
@@ -1312,7 +1312,7 @@ func runSQL(ctx context.Context, stdout io.Writer, cfg config.Config, args []str
 	if !isReadOnlyQuery(query) {
 		return fmt.Errorf("only read-only select/with/pragma queries are allowed")
 	}
-	st, err := store.Open(cfg.DBPath)
+	st, err := store.OpenReadOnly(cfg.DBPath)
 	if err != nil {
 		return err
 	}
@@ -1540,7 +1540,65 @@ Writes a starter TOML config to --config or the standard notcrawl config path.
 
 func isReadOnlyQuery(query string) bool {
 	lower := strings.ToLower(strings.TrimSpace(query))
-	return strings.HasPrefix(lower, "select ") || strings.HasPrefix(lower, "with ") || strings.HasPrefix(lower, "pragma ")
+	for strings.HasSuffix(lower, ";") {
+		lower = strings.TrimSpace(strings.TrimSuffix(lower, ";"))
+	}
+	if lower == "" || strings.Contains(lower, ";") {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(lower, "select "):
+		return true
+	case strings.HasPrefix(lower, "with "):
+		return withSelectsOnly(lower)
+	case strings.HasPrefix(lower, "pragma "):
+		return isReadOnlyPragma(lower)
+	default:
+		return false
+	}
+}
+
+func isReadOnlyPragma(lower string) bool {
+	if strings.Contains(lower, "=") {
+		return false
+	}
+	body := strings.TrimSpace(strings.TrimPrefix(lower, "pragma"))
+	name := body
+	if i := strings.IndexAny(body, " ("); i >= 0 {
+		name = body[:i]
+	}
+	switch strings.TrimSpace(name) {
+	case "", "optimize", "incremental_vacuum", "wal_checkpoint":
+		return false
+	default:
+		return true
+	}
+}
+
+func withSelectsOnly(lower string) bool {
+	depth := 0
+	seenParen := false
+	for i := 0; i < len(lower); i++ {
+		switch lower[i] {
+		case '(':
+			depth++
+			seenParen = true
+		case ')':
+			if depth == 0 {
+				return false
+			}
+			depth--
+			if seenParen && depth == 0 {
+				rest := strings.TrimSpace(lower[i+1:])
+				if strings.HasPrefix(rest, ",") {
+					seenParen = false
+					continue
+				}
+				return strings.HasPrefix(rest, "select ") || strings.HasPrefix(rest, "select(")
+			}
+		}
+	}
+	return false
 }
 
 func printHelp(w io.Writer) {

--- a/cmd/notcrawl/main_test.go
+++ b/cmd/notcrawl/main_test.go
@@ -737,3 +737,93 @@ func TestExportDatabaseInvalidFormatDoesNotTruncateOutput(t *testing.T) {
 		t.Fatalf("invalid export truncated output: %q", string(got))
 	}
 }
+
+func seedSQLArchive(t *testing.T) (dbPath, configPath string) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath = filepath.Join(dir, "notcrawl.db")
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := store.NowMS()
+	if err := st.UpsertPage(ctx, store.Page{
+		ID: "page1", Title: "Launch Plan", Alive: true, Source: "test", SyncedAt: now, LastEditedTime: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return dbPath, filepath.Join(dir, "missing.toml")
+}
+
+func archivePageCountAndUserVersion(t *testing.T, dbPath string) (pages, userVersion int) {
+	t.Helper()
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.DB().QueryRow(`select count(*) from pages`).Scan(&pages); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRow(`pragma user_version`).Scan(&userVersion); err != nil {
+		t.Fatal(err)
+	}
+	return pages, userVersion
+}
+
+func TestSQLCommandRejectsMutatingQueries(t *testing.T) {
+	ctx := context.Background()
+	for _, query := range []string{
+		"SELECT 1; DELETE FROM pages",
+		"WITH x AS (SELECT 1) DELETE FROM pages",
+		"PRAGMA user_version=42",
+	} {
+		t.Run(query, func(t *testing.T) {
+			dbPath, configPath := seedSQLArchive(t)
+			var stdout, stderr bytes.Buffer
+			err := run(ctx, []string{"--config", configPath, "--db", dbPath, "sql", query}, &stdout, &stderr)
+			if err == nil || !strings.Contains(err.Error(), "read-only") {
+				t.Fatalf("expected read-only rejection, got err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+			pages, userVersion := archivePageCountAndUserVersion(t, dbPath)
+			if pages != 1 {
+				t.Fatalf("pages mutated: count=%d", pages)
+			}
+			if userVersion != 0 {
+				t.Fatalf("user_version mutated: %d", userVersion)
+			}
+		})
+	}
+}
+
+func TestSQLCommandAllowsReadQueries(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		query string
+		want  string
+	}{
+		{query: "SELECT title FROM pages", want: "Launch Plan"},
+		{query: "WITH x AS (SELECT title FROM pages) SELECT * FROM x", want: "Launch Plan"},
+		{query: "PRAGMA user_version", want: "0"},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			dbPath, configPath := seedSQLArchive(t)
+			var stdout, stderr bytes.Buffer
+			err := run(ctx, []string{"--config", configPath, "--db", dbPath, "sql", tc.query}, &stdout, &stderr)
+			if err != nil {
+				t.Fatalf("sql %q failed: %v\nstderr:\n%s", tc.query, err, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tc.want) {
+				t.Fatalf("sql %q stdout missing %q:\n%s", tc.query, tc.want, stdout.String())
+			}
+			pages, userVersion := archivePageCountAndUserVersion(t, dbPath)
+			if pages != 1 || userVersion != 0 {
+				t.Fatalf("read query mutated archive: pages=%d user_version=%d", pages, userVersion)
+			}
+		})
+	}
+}

--- a/cmd/notcrawl/main_test.go
+++ b/cmd/notcrawl/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -761,7 +762,7 @@ func seedSQLArchive(t *testing.T) (dbPath, configPath string) {
 
 func archivePageCountAndUserVersion(t *testing.T, dbPath string) (pages, userVersion int) {
 	t.Helper()
-	st, err := store.Open(dbPath)
+	st, err := store.OpenReadOnly(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -781,12 +782,18 @@ func TestSQLCommandRejectsMutatingQueries(t *testing.T) {
 		"SELECT 1; DELETE FROM pages",
 		"WITH x AS (SELECT 1) DELETE FROM pages",
 		"PRAGMA user_version=42",
+		"PRAGMA user_version(42)",
+		"WITH x(v) AS (SELECT 1) DELETE FROM pages RETURNING title",
+		"SELECT ';'; DELETE FROM pages",
+		"SELECT 1; /* comment */ DELETE FROM pages",
+		"PRAGMA query_only=off; DELETE FROM pages",
+		"PRAGMA query_only=off; ATTACH ':memory:' AS other; CREATE TABLE other.t(x)",
 	} {
 		t.Run(query, func(t *testing.T) {
 			dbPath, configPath := seedSQLArchive(t)
 			var stdout, stderr bytes.Buffer
 			err := run(ctx, []string{"--config", configPath, "--db", dbPath, "sql", query}, &stdout, &stderr)
-			if err == nil || !strings.Contains(err.Error(), "read-only") {
+			if err == nil {
 				t.Fatalf("expected read-only rejection, got err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
 			}
 			pages, userVersion := archivePageCountAndUserVersion(t, dbPath)
@@ -809,6 +816,16 @@ func TestSQLCommandAllowsReadQueries(t *testing.T) {
 		{query: "SELECT title FROM pages", want: "Launch Plan"},
 		{query: "WITH x AS (SELECT title FROM pages) SELECT * FROM x", want: "Launch Plan"},
 		{query: "PRAGMA user_version", want: "0"},
+		{query: "PRAGMA table_info(pages)", want: "title"},
+		{query: "WITH x(v) AS (SELECT 1) SELECT v FROM x", want: "1"},
+		{query: "WITH RECURSIVE x(v) AS (SELECT 1 UNION ALL SELECT v+1 FROM x WHERE v<3) SELECT max(v) FROM x", want: "3"},
+		{query: "WITH x AS (SELECT ')') SELECT * FROM x", want: ")"},
+		{query: "SELECT ';' AS \"semi;colon\"", want: "semi;colon"},
+		{query: "SELECT 'it''s;quoted'", want: "it's;quoted"},
+		{query: "SELECT 1 AS [semi;colon]", want: "semi;colon"},
+		{query: "SELECT 1 AS `semi;colon`", want: "semi;colon"},
+		{query: "SELECT 1 /* ; */; -- trailing ; comment", want: "1"},
+		{query: "SELECT 1 -- ;\n; /* trailing */", want: "1"},
 	} {
 		t.Run(tc.query, func(t *testing.T) {
 			dbPath, configPath := seedSQLArchive(t)
@@ -825,5 +842,54 @@ func TestSQLCommandAllowsReadQueries(t *testing.T) {
 				t.Fatalf("read query mutated archive: pages=%d user_version=%d", pages, userVersion)
 			}
 		})
+	}
+}
+
+func TestSQLCommandDoesNotCreateArchive(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "missing.db")
+	err := run(context.Background(), []string{"--config", filepath.Join(dir, "missing.toml"), "--db", dbPath, "sql", "SELECT 1"}, io.Discard, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "run sync first") {
+		t.Fatalf("expected archive preparation hint, got %v", err)
+	}
+	if _, err := os.Stat(dbPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("SQL created missing archive: %v", err)
+	}
+}
+
+func TestSQLCommandDoesNotMigrateLegacyArchive(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "legacy.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE pages (title TEXT); INSERT INTO pages VALUES ('Legacy page')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	args := []string{"--config", filepath.Join(dir, "missing.toml"), "--db", dbPath, "sql"}
+	if err := run(context.Background(), append(args, "SELECT title FROM pages"), &stdout, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "Legacy page") {
+		t.Fatalf("missing legacy result: %s", stdout.String())
+	}
+	if err := run(context.Background(), append(args, "SELECT api_blocks_synced FROM pages"), io.Discard, io.Discard); err == nil {
+		t.Fatal("expected missing legacy column error")
+	}
+	after, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("SQL modified legacy archive")
 	}
 }


### PR DESCRIPTION
`notcrawl sql` promised read-only access but opened a writable archive. On current main, `SELECT 1; DELETE FROM pages` deletes archived pages and write PRAGMAs change SQLite metadata.

Open the archive with the existing read-only store and reject additional statements using quote/comment-aware boundary scanning. SQLite enforces write rejection; it also parses CTEs, so valid column lists, recursive queries, and quoted punctuation keep working. SQL no longer creates or migrates archives; README and SPEC document using `sync` for preparation. Thanks @SebTardif for the original fix and reproduction.

Validation with the actual built CLI on macOS and synthetic SQLite fixtures:

- Main deletes the seeded page with a trailing DELETE; the repaired binary rejects it and preserves the row.
- WITH DELETE, both write-PRAGMA forms, and a query-only/ATTACH statement chain fail; the page count remains one and `user_version` remains zero.
- CTE column lists, recursive CTEs, quoted parentheses/semicolons, identifiers, and comments return their expected results.
- Missing archives remain absent with a preparation hint. Existing legacy columns remain queryable, unavailable columns fail, and the legacy database remains byte-for-byte unchanged.
- Full Go tests, vet, dead-code analysis, formatting, and release-script tests pass. Codex branch autoreview against `origin/main` is clean through P2.

Regression tests cover these read/write and archive lifecycle cases. No private Notion archive or credentials were used.
