### PR TITLE
chore(deps): update CrawlKit to v0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Dependencies
 
+- Update CrawlKit to v0.14.9, including upstream snapshot-path validation and scheduler-history recovery fixes.
 - Update Go to 1.27.1, SQLite to v1.58.0, terminal width handling to go-runewidth v0.0.29, and the TruffleHog secret-scanning action to v3.97.4.
 - Update CrawlKit to v0.14.8 so release checks time out after 30 seconds instead of hanging on an unresponsive server.
 - Update Go to 1.27.0, SQLite to v1.57.0, indirect Go modules, vulnerability and dead-code tooling, and the stale and secret-scanning GitHub Actions.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 require (
 	github.com/alecthomas/kong v1.16.1
-	github.com/openclaw/crawlkit v0.14.8
+	github.com/openclaw/crawlkit v0.14.9
 	modernc.org/sqlite v1.58.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
-github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
+github.com/openclaw/crawlkit v0.14.9 h1:nlLxcBvwtgVw5WehmjQCrRyfIYrDyQbJ3zPyKhUeta0=
+github.com/openclaw/crawlkit v0.14.9/go.mod h1:jGtyzzrIcBPzj0fTiP2I+/LcfTMsfT/o9Zx8jh0HMDc=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
Update CrawlKit from v0.14.8 to v0.14.9, including upstream snapshot-path validation and interrupted scheduler-history recovery fixes. Keep SQLite's required libc v1.75.6 pairing; other direct dependencies and pinned Actions are current.

Validation: `make check` passed, including module verification/tidiness, govulncheck, formatting, vet, dead-code analysis, the full test suite, release-script tests, real CLI smoke checks, and both GoReleaser snapshot configurations. Codex branch autoreview against `origin/main` is clean through P2.

The actual built CLI also exported and published a synthetic archive to a local Git repository, subscribed into a fresh archive, searched and exported the imported page, then rejected an update with an escaping snapshot path while retaining the existing page. All data and Git remotes were local fixtures.
