### PR TITLE
docs(changelog): prepare 0.5.9 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,18 @@
 
 ## 0.5.9 - Unreleased
 
-### Added
-
-- Add per-invocation `sync --verbose` diagnostics on stderr with phases, counts, API attempts, HTTP statuses, and retry delays while excluding private request data and upstream errors. Thanks @transitive-bullshit.
-
-### Dependencies
-
-- Update CrawlKit to v0.14.9, including upstream snapshot-path validation and scheduler-history recovery fixes.
-- Update Go to 1.27.1, SQLite to v1.58.0, terminal width handling to go-runewidth v0.0.29, and the TruffleHog secret-scanning action to v3.97.4.
-- Update CrawlKit to v0.14.8 so release checks time out after 30 seconds instead of hanging on an unresponsive server.
-- Update Go to 1.27.0, SQLite to v1.57.0, indirect Go modules, vulnerability and dead-code tooling, and the stale and secret-scanning GitHub Actions.
-
-### Fixed
+**Highlights:** Safer SQL inspection and clearer sync diagnostics.
 
 - Enforce read-only SQL access without rejecting valid CTEs, quoted punctuation, or comments; leave archive creation and upgrades to sync. Thanks @SebTardif.
+- Add per-invocation `sync --verbose` diagnostics on stderr with phases, counts, API attempts, HTTP statuses, and retry delays while excluding private request data and upstream errors. Thanks @transitive-bullshit.
+- Bound official Notion API success responses to 8 MiB and fail oversized responses without retrying. Thanks @SebTardif.
 - Return gzip and output-file finalization errors before committing Git share snapshots. Thanks @SebTardif.
 - Return output-file close errors before reporting successful CSV/TSV database exports. Thanks @SebTardif.
-- Bound the release-check HTTP client to a 5-second timeout so a stalled GitHub Releases host cannot pin the
-  background version notify. Thanks @SebTardif.
 - Reject repeated official API cursors without limiting healthy pagination or rewriting opaque cursor values. Thanks @SebTardif.
 - Reject repeated Notion MCP `tools/list` cursors and cap discovery at 100 pages so a malformed pager cannot livelock sync.
+- Bound the release-check HTTP client to a 5-second timeout so a stalled GitHub Releases host cannot pin the background version notification. Thanks @SebTardif.
+- Update CrawlKit to v0.14.9, including upstream snapshot-path validation, scheduler-history recovery, and bounded release checks.
+- Update Go to 1.27.1, SQLite to v1.58.0, go-runewidth to v0.0.29, indirect Go modules, vulnerability and dead-code tooling, and the stale and secret-scanning GitHub Actions.
 
 ## v0.5.8 - 2026-08-14
 


### PR DESCRIPTION
Prepare the 0.5.9 patch release notes, ordered by user impact, with a short highlights lead-in and consolidated dependency history. Preserve released sections byte-for-byte and credit contributors.

Land this documentation after #118, #116, and #119. The notes include those prepared changes as well as all user-visible work since v0.5.8. Reconcile the final Unreleased section against these notes if earlier lands overlap the changelog hunk.

Validation: reconciled the 12 main commits since v0.5.8 and the three prepared PRs; verified released sections are unchanged; Codex branch autoreview against `origin/main` is clean through P2. The fixes and dependency update have full tests and real built-CLI proof on their own PRs. This PR changes documentation only.

Recommend patch 0.5.9: fixes, dependency maintenance, and a small diagnostic flag do not warrant a minor release. Publishing remains a separate action: stamp the release date on approved main, verify exact-head CI, then use the existing unified workflow for GitHub assets, signed/notarized macOS binaries, Linux packages, and Homebrew handoff. No tag or publication is performed here.
