### PR TITLE
feat: add opt-in Desktop workspace selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ Secrets are not included in Markdown or git share snapshots.
 
 See [`config.example.toml`](config.example.toml) for every setting.
 
+To limit future Desktop ingestion to selected workspaces, set `space_ids` under
+`[notion.desktop]` in your config:
+
+```toml
+[notion.desktop]
+enabled = true
+space_ids = ["01234567-89ab-cdef-0123-456789abcdef"]
+```
+
+An empty list (the default) includes all cached workspaces. IDs match regardless
+of case or UUID hyphens. Find known IDs with
+`notcrawl sql "SELECT id, name FROM spaces"` in an existing archive. The filter
+applies to `sync --source desktop`, `tap`, and the Desktop phase of `sync`.
+Rows without a workspace ID are skipped when a list is set.
+
+The list filters workspace content, not the complete archive: existing rows and
+their Markdown remain, shared user metadata is still imported, and cache
+snapshots still contain the complete local Notion database. API and MCP sync
+are unaffected. For a new Desktop-only archive, use separate `db_path`,
+`cache_dir`, and `markdown_dir` settings and disable the API and MCP sources.
+
 Interactive terminal runs check for a newer release once per day. `notcrawl check-update` checks immediately; set `NOTCRAWL_NO_UPDATE_CHECK=1` or `CRAWLKIT_NO_UPDATE_CHECK=1` to disable the passive check.
 
 ## Safety model

--- a/SPEC.md
+++ b/SPEC.md
@@ -63,6 +63,16 @@ Desktop sync must:
 Desktop cache coverage is opportunistic. It only includes what Notion has
 cached, downloaded, or recently touched locally.
 
+`notion.desktop.space_ids` optionally limits future Desktop ingestion to listed
+workspace IDs (case-insensitive, with or without UUID hyphens). An absent or
+empty list preserves all-workspace ingestion. The filter covers spaces, teams,
+collections, pages, blocks, raw block records, and comments, including explicit
+tombstones. With a nonempty list, records without a workspace ID are skipped.
+Excluded existing archive rows are retained unchanged, remain searchable, and
+remain eligible for Markdown export. Shared users and complete source snapshots
+are not filtered. API and MCP coverage is unchanged; this is not an archive
+cleanup or access-control feature.
+
 ### API Source
 
 API sync uses `NOTION_TOKEN` by default. It must:

--- a/cmd/notcrawl/main.go
+++ b/cmd/notcrawl/main.go
@@ -452,7 +452,7 @@ func runSync(ctx context.Context, stdout, stderr io.Writer, cfg config.Config, a
 	switch *source {
 	case "desktop":
 		trace.start("desktop")
-		s, err := notiondesktop.Ingest(ctx, st, cfg.Notion.Desktop.Path, cfg.CacheDir)
+		s, err := notiondesktop.Ingest(ctx, st, cfg.Notion.Desktop.Path, cfg.CacheDir, cfg.Notion.Desktop.SpaceIDs)
 		if err != nil {
 			return err
 		}
@@ -494,7 +494,7 @@ func runSync(ctx context.Context, stdout, stderr io.Writer, cfg config.Config, a
 	case "all":
 		if cfg.Notion.Desktop.Enabled {
 			trace.start("desktop")
-			s, err := notiondesktop.Ingest(ctx, st, cfg.Notion.Desktop.Path, cfg.CacheDir)
+			s, err := notiondesktop.Ingest(ctx, st, cfg.Notion.Desktop.Path, cfg.CacheDir, cfg.Notion.Desktop.SpaceIDs)
 			if err != nil {
 				return err
 			}

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,8 @@ markdown_dir = "~/.notcrawl/pages"
 [notion.desktop]
 enabled = true
 path = ""
+# Optional workspace allowlist for future Desktop ingestion; empty means all.
+space_ids = []
 
 [notion.api]
 enabled = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,9 @@ type NotionConfig struct {
 }
 
 type DesktopConfig struct {
-	Enabled bool   `toml:"enabled"`
-	Path    string `toml:"path"`
+	Enabled  bool     `toml:"enabled"`
+	Path     string   `toml:"path"`
+	SpaceIDs []string `toml:"space_ids"`
 }
 
 type APIConfig struct {
@@ -181,6 +182,11 @@ func defaultDesktopPath() string {
 }
 
 func (c *Config) Resolve() error {
+	for _, id := range c.Notion.Desktop.SpaceIDs {
+		if strings.TrimSpace(id) == "" {
+			return fmt.Errorf("notion.desktop.space_ids must not contain empty IDs")
+		}
+	}
 	if strings.TrimSpace(c.Notion.Desktop.Path) == "" {
 		c.Notion.Desktop.Path = defaultDesktopPath()
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,8 +4,31 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
+
+func TestDesktopWorkspaceConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if _, err := WriteStarter(path); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil || len(cfg.Notion.Desktop.SpaceIDs) != 0 {
+		t.Fatalf("starter must include all workspaces: %+v, %v", cfg.Notion.Desktop, err)
+	}
+	if err := os.WriteFile(path, []byte("[notion.desktop]\nspace_ids = ['workspace-a', 'workspace-b']\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = Load(path)
+	if err != nil || len(cfg.Notion.Desktop.SpaceIDs) != 2 || cfg.Notion.Desktop.SpaceIDs[1] != "workspace-b" {
+		t.Fatalf("workspace allowlist not loaded: %+v, %v", cfg.Notion.Desktop, err)
+	}
+	cfg.Notion.Desktop.SpaceIDs = []string{" "}
+	if err := cfg.Resolve(); err == nil || !strings.Contains(err.Error(), "space_ids") {
+		t.Fatalf("blank workspace ID accepted: %v", err)
+	}
+}
 
 func TestDefaultUsesCurrentNotionAPIVersion(t *testing.T) {
 	cfg := Default()

--- a/internal/notiondesktop/desktop.go
+++ b/internal/notiondesktop/desktop.go
@@ -51,7 +51,11 @@ func Inspect(path string) (Source, error) {
 	return Source{Path: path, Available: true, SizeBytes: info.Size()}, nil
 }
 
-func Ingest(ctx context.Context, st *store.Store, path, cacheDir string) (Summary, error) {
+func Ingest(ctx context.Context, st *store.Store, path, cacheDir string, spaceIDs []string) (Summary, error) {
+	scope := make(spaceScope, len(spaceIDs))
+	for _, id := range spaceIDs {
+		scope[normalizeSpaceID(id)] = true
+	}
 	source, err := Inspect(path)
 	if err != nil || !source.Available {
 		return Summary{Source: source}, err
@@ -70,22 +74,22 @@ func Ingest(ctx context.Context, st *store.Store, path, cacheDir string) (Summar
 	syncedAt := store.NowMS()
 	if err := st.WithTransaction(ctx, func() error {
 		return st.DeferPageFTS(ctx, func() error {
-			if s.Spaces, err = ingestSpaces(ctx, st, db); err != nil {
+			if s.Spaces, err = ingestSpaces(ctx, st, db, scope); err != nil {
 				return err
 			}
 			if s.Users, err = ingestUsers(ctx, st, db); err != nil {
 				return err
 			}
-			if s.Teams, err = ingestTeams(ctx, st, db); err != nil {
+			if s.Teams, err = ingestTeams(ctx, st, db, scope); err != nil {
 				return err
 			}
-			if s.Collections, err = ingestCollections(ctx, st, db); err != nil {
+			if s.Collections, err = ingestCollections(ctx, st, db, scope); err != nil {
 				return err
 			}
-			if s.Pages, s.Blocks, s.RawRecords, err = ingestBlocks(ctx, st, db, syncedAt); err != nil {
+			if s.Pages, s.Blocks, s.RawRecords, err = ingestBlocks(ctx, st, db, syncedAt, scope); err != nil {
 				return err
 			}
-			if s.Comments, err = ingestComments(ctx, st, db, syncedAt); err != nil {
+			if s.Comments, err = ingestComments(ctx, st, db, syncedAt, scope); err != nil {
 				return err
 			}
 			addedSpaces, err := st.EnsureSpaceFallbacks(ctx, SourceName)
@@ -170,7 +174,17 @@ func pruneDesktopSnapshots(cacheDir string, keep int, current string) error {
 	return nil
 }
 
-func ingestSpaces(ctx context.Context, st *store.Store, db *sql.DB) (int, error) {
+type spaceScope map[string]bool
+
+func normalizeSpaceID(id string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(id), "-", ""))
+}
+
+func (s spaceScope) includes(id string) bool {
+	return len(s) == 0 || (id != "" && s[normalizeSpaceID(id)])
+}
+
+func ingestSpaces(ctx context.Context, st *store.Store, db *sql.DB, scope spaceScope) (int, error) {
 	rows, err := db.QueryContext(ctx, `select id, coalesce(name, ''), coalesce(json_object(
 		'id', id, 'name', name, 'pages', pages, 'settings', settings, 'created_time', created_time, 'last_edited_time', last_edited_time
 	), '{}') from space`)
@@ -183,6 +197,9 @@ func ingestSpaces(ctx context.Context, st *store.Store, db *sql.DB) (int, error)
 		var id, name, raw string
 		if err := rows.Scan(&id, &name, &raw); err != nil {
 			return n, err
+		}
+		if !scope.includes(id) {
+			continue
 		}
 		if name == "" {
 			name = id
@@ -217,8 +234,8 @@ func ingestUsers(ctx context.Context, st *store.Store, db *sql.DB) (int, error) 
 	return n, rows.Err()
 }
 
-func ingestTeams(ctx context.Context, st *store.Store, db *sql.DB) (int, error) {
-	rows, err := db.QueryContext(ctx, `select id, space_id, parent_id, parent_table, coalesce(name, ''),
+func ingestTeams(ctx context.Context, st *store.Store, db *sql.DB, scope spaceScope) (int, error) {
+	rows, err := db.QueryContext(ctx, `select id, coalesce(space_id, ''), parent_id, parent_table, coalesce(name, ''),
 		coalesce(json_object('id', id, 'space_id', space_id, 'parent_id', parent_id, 'parent_table', parent_table,
 			'name', name, 'description', description, 'team_pages', team_pages, 'settings', settings), '{}')
 		from team where coalesce(archived_at, 0) = 0`)
@@ -231,6 +248,9 @@ func ingestTeams(ctx context.Context, st *store.Store, db *sql.DB) (int, error) 
 		var x store.Team
 		if err := rows.Scan(&x.ID, &x.SpaceID, &x.ParentID, &x.ParentTable, &x.Name, &x.RawJSON); err != nil {
 			return n, err
+		}
+		if !scope.includes(x.SpaceID) {
+			continue
 		}
 		if x.Name == "" {
 			x.Name = x.ID
@@ -245,8 +265,8 @@ func ingestTeams(ctx context.Context, st *store.Store, db *sql.DB) (int, error) 
 	return n, rows.Err()
 }
 
-func ingestCollections(ctx context.Context, st *store.Store, db *sql.DB) (int, error) {
-	rows, err := db.QueryContext(ctx, `select id, space_id, parent_id, parent_table, coalesce(name, ''), coalesce(schema, ''), coalesce(format, ''),
+func ingestCollections(ctx context.Context, st *store.Store, db *sql.DB, scope spaceScope) (int, error) {
+	rows, err := db.QueryContext(ctx, `select id, coalesce(space_id, ''), parent_id, parent_table, coalesce(name, ''), coalesce(schema, ''), coalesce(format, ''),
 		coalesce(json_object('id', id, 'space_id', space_id, 'parent_id', parent_id, 'parent_table', parent_table,
 			'name', name, 'schema', schema, 'format', format), '{}')
 		from collection where alive = 1`)
@@ -259,6 +279,9 @@ func ingestCollections(ctx context.Context, st *store.Store, db *sql.DB) (int, e
 		var x store.Collection
 		if err := rows.Scan(&x.ID, &x.SpaceID, &x.ParentID, &x.ParentTable, &x.Name, &x.SchemaJSON, &x.FormatJSON, &x.RawJSON); err != nil {
 			return n, err
+		}
+		if !scope.includes(x.SpaceID) {
+			continue
 		}
 		x.Name = notiontext.TitleFromProperties(x.Name)
 		if x.Name == "" {
@@ -291,8 +314,8 @@ type localBlock struct {
 	Text           string
 }
 
-func ingestBlocks(ctx context.Context, st *store.Store, db *sql.DB, syncedAt int64) (pages int, blocks int, rawRecords int, err error) {
-	rows, err := db.QueryContext(ctx, `select id, space_id, type, coalesce(properties, ''), coalesce(content, ''),
+func ingestBlocks(ctx context.Context, st *store.Store, db *sql.DB, syncedAt int64, scope spaceScope) (pages int, blocks int, rawRecords int, err error) {
+	rows, err := db.QueryContext(ctx, `select id, coalesce(space_id, ''), type, coalesce(properties, ''), coalesce(content, ''),
 		coalesce(collection_id, ''), coalesce(cast(created_time as integer), 0), coalesce(cast(last_edited_time as integer), 0),
 		coalesce(parent_id, ''), coalesce(parent_table, ''), alive, coalesce(format, ''),
 		coalesce(json_object('id', id, 'space_id', space_id, 'type', type, 'properties', properties, 'content', content,
@@ -311,6 +334,9 @@ func ingestBlocks(ctx context.Context, st *store.Store, db *sql.DB, syncedAt int
 		if err := rows.Scan(&b.ID, &b.SpaceID, &b.Type, &b.PropertiesJSON, &b.ContentJSON, &b.CollectionID, &b.CreatedTime,
 			&b.LastEditedTime, &b.ParentID, &b.ParentTable, &alive, &b.FormatJSON, &b.RawJSON); err != nil {
 			return pages, blocks, rawRecords, err
+		}
+		if !scope.includes(b.SpaceID) {
+			continue
 		}
 		b.Alive = alive != 0
 		b.Text = blockText(b.PropertiesJSON)
@@ -462,8 +488,8 @@ func blockText(raw string) string {
 	return notiontext.PlainFromJSON(raw)
 }
 
-func ingestComments(ctx context.Context, st *store.Store, db *sql.DB, syncedAt int64) (int, error) {
-	rows, err := db.QueryContext(ctx, `select id, parent_id, space_id, coalesce(text, ''), coalesce(created_by_id, ''),
+func ingestComments(ctx context.Context, st *store.Store, db *sql.DB, syncedAt int64, scope spaceScope) (int, error) {
+	rows, err := db.QueryContext(ctx, `select id, parent_id, coalesce(space_id, ''), coalesce(text, ''), coalesce(created_by_id, ''),
 		coalesce(cast(created_time as integer), 0), coalesce(cast(last_edited_time as integer), 0), alive,
 		coalesce(json_object('id', id, 'parent_id', parent_id, 'space_id', space_id, 'text', text, 'content', content,
 			'created_by_id', created_by_id, 'created_time', created_time, 'last_edited_time', last_edited_time, 'alive', alive), '{}')
@@ -481,6 +507,9 @@ func ingestComments(ctx context.Context, st *store.Store, db *sql.DB, syncedAt i
 		var alive int
 		if err := rows.Scan(&c.ID, &c.ParentID, &c.SpaceID, &c.Text, &c.CreatedByID, &c.CreatedTime, &c.LastEditedTime, &alive, &c.RawJSON); err != nil {
 			return n, err
+		}
+		if !scope.includes(c.SpaceID) {
+			continue
 		}
 		c.PageID = c.ParentID
 		c.Text = notiontext.PlainFromJSON(c.Text)

--- a/internal/notiondesktop/desktop_test.go
+++ b/internal/notiondesktop/desktop_test.go
@@ -96,7 +96,7 @@ func TestIngestBlocksDerivesUntitledPageFromChildText(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer st.Close()
-	if _, _, _, err := ingestBlocks(ctx, st, src, 1); err != nil {
+	if _, _, _, err := ingestBlocks(ctx, st, src, 1, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -147,7 +147,7 @@ func TestIngestBlocksPreservesRowsMissingFromLatestSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer st.Close()
-	if _, _, _, err := ingestBlocks(ctx, st, src, 1); err != nil {
+	if _, _, _, err := ingestBlocks(ctx, st, src, 1, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Archived API payload", Alive: false, Source: "api", SyncedAt: 9}); err != nil {
@@ -167,13 +167,13 @@ func TestIngestBlocksPreservesRowsMissingFromLatestSnapshot(t *testing.T) {
 	if err := st.UpsertBlock(ctx, store.Block{ID: "child3", PageID: "page3", ParentID: "page3", Type: "paragraph", Text: "API body", Alive: true, Source: "api", SyncedAt: 10}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := ingestBlocks(ctx, st, src, 2); err != nil {
+	if _, _, _, err := ingestBlocks(ctx, st, src, 2, nil); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := src.ExecContext(ctx, `delete from block where id in ('child1', 'page2', 'page3', 'child3')`); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := ingestBlocks(ctx, st, src, 3); err != nil {
+	if _, _, _, err := ingestBlocks(ctx, st, src, 3, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -268,7 +268,7 @@ func TestIngestBlocksPreservesPreviousSnapshotWhenCacheQueryIsEmpty(t *testing.T
 	if err := st.UpsertPage(ctx, store.Page{ID: "page1", Title: "Keep me", Alive: true, Source: SourceName, SyncedAt: 1}); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, _, err := ingestBlocks(ctx, st, src, 2); err != nil {
+	if _, _, _, err := ingestBlocks(ctx, st, src, 2, nil); err != nil {
 		t.Fatal(err)
 	}
 	pages, err := st.Pages(ctx)
@@ -308,7 +308,7 @@ func TestIngestCommentsTreatsEmptyCacheAsNonAuthoritative(t *testing.T) {
 	if err := st.UpsertComment(ctx, store.Comment{ID: "comment1", PageID: "page1", Text: "Keep me", Alive: true, Source: SourceName, SyncedAt: 1}); err != nil {
 		t.Fatal(err)
 	}
-	count, err := ingestComments(ctx, st, src, 2)
+	count, err := ingestComments(ctx, st, src, 2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/notiondesktop/testdata/workspaces.sql
+++ b/internal/notiondesktop/testdata/workspaces.sql
@@ -1,0 +1,28 @@
+-- Synthetic Notion Desktop cache for scoped ingestion and CLI smoke checks.
+create table space (id text primary key, name text, pages text, settings text, created_time integer, last_edited_time integer);
+create table notion_user (id text primary key, name text, email text, given_name text, family_name text, profile_photo text);
+create table team (id text primary key, space_id text, parent_id text, parent_table text, name text, description text, team_pages text, settings text, archived_at integer);
+create table collection (id text primary key, space_id text, parent_id text, parent_table text, name text, schema text, format text, alive integer);
+create table block (id text primary key, space_id text, type text, properties text, content text, collection_id text, created_time integer, last_edited_time integer, parent_id text, parent_table text, alive integer, format text);
+create table comment (id text primary key, parent_id text, space_id text, text text, content text, created_by_id text, created_time integer, last_edited_time integer, alive integer);
+
+insert into space values
+('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Selected', '[]', '{}', 1, 1),
+('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Excluded', '[]', '{}', 1, 1);
+insert into notion_user values ('shared-user', 'Shared user', '', '', '', '');
+insert into team values
+('team-a', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '', '', 'Selected team', '', '[]', '{}', 0),
+('team-b', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '', '', 'Excluded team', '', '[]', '{}', 0);
+insert into collection values
+('collection-a', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '', '', 'Selected database', '{}', '{}', 1),
+('collection-b', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '', '', 'Excluded database', '{}', '{}', 1);
+insert into block values
+('page-a', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'page', '{"title":[["Selected page"]]}', '["block-a"]', '', 1, 1, '', '', 1, '{}'),
+('block-a', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'text', '{"title":[["Selected body"]]}', '[]', '', 1, 1, 'page-a', 'block', 1, '{}'),
+('page-b', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'page', '{"title":[["Excluded page"]]}', '["block-b"]', '', 1, 1, '', '', 1, '{}'),
+('block-b', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'text', '{"title":[["Excluded body"]]}', '[]', '', 1, 1, 'page-b', 'block', 1, '{}'),
+('page-unknown', null, 'page', '{"title":[["Unknown workspace"]]}', '[]', '', 1, 1, '', '', 1, '{}');
+insert into comment values
+('comment-a', 'page-a', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '[["Selected comment"]]', '[]', 'shared-user', 1, 1, 1),
+('comment-b', 'page-b', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '[["Excluded comment"]]', '[]', 'shared-user', 1, 1, 1),
+('comment-unknown', 'page-unknown', null, '[["Unknown comment"]]', '[]', 'shared-user', 1, 1, 1);

--- a/internal/notiondesktop/workspaces_test.go
+++ b/internal/notiondesktop/workspaces_test.go
@@ -1,0 +1,85 @@
+package notiondesktop
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestIngestWorkspaceScope(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "desktop.db")
+	source, err := sql.Open("sqlite", sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	fixture, err := os.ReadFile("testdata/workspaces.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.Exec(string(fixture)); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cacheDir := filepath.Join(dir, "cache")
+	scope := []string{" AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA "}
+	summary, err := Ingest(ctx, st, sourcePath, cacheDir, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Spaces != 1 || summary.Users != 1 || summary.Teams != 1 || summary.Collections != 1 || summary.Pages != 1 || summary.Blocks != 2 || summary.RawRecords != 2 || summary.Comments != 1 {
+		t.Fatalf("unexpected scoped ingestion: %+v", summary)
+	}
+	for _, table := range []string{"spaces", "teams", "collections", "pages", "blocks", "raw_records", "comments"} {
+		column := "space_id"
+		if table == "spaces" {
+			column = "id"
+		}
+		var count int
+		if err := st.DB().QueryRow("select count(*) from "+table+" where "+column+" != ?", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").Scan(&count); err != nil || count != 0 {
+			t.Fatalf("unexpected rows in %s: count=%d err=%v", table, count, err)
+		}
+	}
+
+	// An empty list restores the existing all-workspace behavior.
+	summary, err = Ingest(ctx, st, sourcePath, cacheDir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Pages != 3 || summary.Blocks != 5 || summary.Comments != 3 {
+		t.Fatalf("unexpected unscoped ingestion: %+v", summary)
+	}
+
+	// Narrowing coverage must not apply an excluded workspace's tombstones.
+	if _, err := source.Exec(`update block set alive = 0; update comment set alive = 0`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Ingest(ctx, st, sourcePath, cacheDir, scope); err != nil {
+		t.Fatal(err)
+	}
+	for table, ids := range map[string][]string{"pages": {"page-a", "page-b", "page-unknown"}, "blocks": {"block-a", "block-b", "page-unknown"}, "comments": {"comment-a", "comment-b", "comment-unknown"}} {
+		for i, id := range ids {
+			want := i != 0
+			var alive bool
+			if err := st.DB().QueryRow("select alive from "+table+" where id = ?", id).Scan(&alive); err != nil || alive != want {
+				t.Fatalf("%s/%s alive=%t want=%t err=%v", table, id, alive, want, err)
+			}
+		}
+	}
+
+	// Multiple IDs select a union; duplicate normalized IDs do not duplicate rows.
+	summary, err = Ingest(ctx, st, sourcePath, cacheDir, []string{scope[0], "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"})
+	if err != nil || summary.Pages != 2 || summary.Blocks != 4 || summary.Comments != 2 {
+		t.Fatalf("unexpected union ingestion: %+v, %v", summary, err)
+	}
+}


### PR DESCRIPTION
Desktop sync currently ingests every workspace in the local Notion cache. Add an opt-in `notion.desktop.space_ids` allowlist for `sync --source desktop`, `tap`, and the Desktop phase of `sync`.

An empty list preserves existing behavior. Matching ignores UUID hyphens and case; selected workspaces include their pages, blocks, collections, teams, comments, and raw block records. Excluded existing archive rows remain unchanged, including when the cache contains tombstones. Records without a workspace ID are skipped when filtering is enabled.

README, SPEC, and the example config explain the scope: shared users and complete cache snapshots remain, and API/MCP sync is unaffected. A new Desktop-only archive needs separate data paths and disabled remote sources.

Fixes #99. Thanks @transitive-bullshit for the request. The changelog entry is in the separate final notes/dependency PR to keep the branches independent.

Validation: full Go tests; vet and dead-code checks; formatting; macOS release-script regressions; local autoreview clean through P2. Built CLI proof on the committed synthetic Desktop fixture verified all three entry points, SQLite/Markdown/search/SQL output, unchanged source bytes, retained excluded content after narrowing, selected tombstones, and blank-ID rejection before archive creation. Hosted CI passed on `d88d66da0d5b32c429cb12fae38a5b43b08a9113`, and committed-branch autoreview is scoped-clean through P2.

Observed output from the actual built CLI on that head, using the committed synthetic Desktop SQLite fixture (temporary root replaced with `<fixture>`):

```text
$ notcrawl sync --source desktop
desktop: pages=1 blocks=2 teams=1 collections=1 comments=1 snapshot=<fixture>/cache/notion-desktop-1788769572475.db
$ notcrawl sql SELECT id, title FROM pages ORDER BY id
id	title
page-a	Selected page
$ notcrawl export-md
exported 1 pages to <fixture>/pages
$ notcrawl search Selected
page	page-a	Selected page	[Selected] body
comment	comment-a	Selected page	[Selected] comment
Source SHA-256 unchanged: true
$ notcrawl tap
desktop: pages=3 blocks=5 teams=2 collections=2 comments=3 snapshot=<fixture>/cache/notion-desktop-1788769572698.db
$ notcrawl sql SELECT id, alive FROM pages ORDER BY id
id	alive
page-a	1
page-b	1
page-unknown	1
$ notcrawl sync
desktop: pages=1 blocks=2 teams=1 collections=1 comments=1 snapshot=<fixture>/cache/notion-desktop-1788769572861.db
$ notcrawl sql SELECT id, alive FROM pages ORDER BY id
id	alive
page-a	0
page-b	1
page-unknown	1
```

The first run configures one workspace, the second uses an empty list, and the third narrows after setting source tombstones. Full CI and proof: https://github.com/openclaw/notcrawl/pull/122#issuecomment-5567655596.
