### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.0 - 2026-09-07
 
 **Highlights:** Choose which workspaces Desktop sync adds to your archive.
 


### PR DESCRIPTION
Date the v0.6.0 changelog for September 7, preserving the Desktop workspace selection highlight and contributor credit from #122 and #123.

Release builds inject their version through the existing GoReleaser linker flags; development builds retain `dev`. No dependency or runtime changes are included.

Validation: `make check` passed in full, including vulnerability checks, tests, lint, CLI smoke, release-script checks, and both credential-free snapshot configurations. Autoreview is scoped-clean through P2. Publish through the unified workflow only after CI passes on the resulting main commit.
