### PR TITLE
fix: preserve archive search consistency and sanitize signed file URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Document fail-closed export errors for malformed protected JSON, private read-only diagnosis, separate-path recovery limits, and partial or stale output after failure.
 - Sanitize signed file URLs inside known Desktop raw JSON envelopes and fallback copies during export, including existing archives, without changing local recovery bytes or exact numeric values.
 - Remove structured signed-file URL credentials from outgoing shares and Markdown without changing local raw recovery payloads or ordinary link parameters.
 - Commit API content batches and their search index together, retaining searchable progress when a later request fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Remove structured signed-file URL credentials from outgoing shares and Markdown without changing local raw recovery payloads or ordinary link parameters.
+- Commit API content batches and their search index together, retaining searchable progress when a later request fails.
+- Reject incomplete API continuation metadata without retiring unseen blocks or marking page coverage complete.
+- Preserve completed API and Desktop todo checkboxes in Markdown exports.
+
 ## 0.6.0 - 2026-09-07
 
 **Highlights:** Choose which workspaces Desktop sync adds to your archive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Sanitize signed file URLs inside known Desktop raw JSON envelopes and fallback copies during export, including existing archives, without changing local recovery bytes or exact numeric values.
 - Remove structured signed-file URL credentials from outgoing shares and Markdown without changing local raw recovery payloads or ordinary link parameters.
 - Commit API content batches and their search index together, retaining searchable progress when a later request fails.
 - Reject incomplete API continuation metadata without retiring unseen blocks or marking page coverage complete.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ Structured signed-file URL credentials are removed from these outgoing
 projections; ordinary link parameters and private local raw recovery payloads
 are retained.
 
+### Troubleshooting export failures
+
+`export-md` and `publish` stop with an error if protected provider JSON is
+malformed or a signed file URL cannot be safely sanitized. They do not skip
+the record or remove its raw payload from the local archive.
+
+Before investigating, stop archive writers and make a consistent, private
+SQLite backup, including any uncheckpointed WAL data. Keep the original
+archive and backup unchanged. Use read-only queries on the backup to inspect
+JSON validity and record counts; do not print or share raw payloads, signed
+URLs, or credentials in diagnostics or issue reports.
+
+If the source is still available, use a separate configuration with new
+`db_path`, `cache_dir`, `markdown_dir`, and `[share].repo_path` locations to
+reimport it. Select the intended source explicitly. Desktop cache coverage is
+limited, and a normal resync is not guaranteed to repair historical records.
+Preserve the original archive for records the source can no longer supply.
+
+A failed export can leave partial or stale files in the Markdown or share
+directory; output changes are not rolled back atomically. Do not manually
+commit, push, or distribute that output. Retry into separate output locations
+after resolving the source problem, and require a successful export before
+using the result.
+
 ## Configuration
 
 `notcrawl init` writes `~/.notcrawl/config.toml`. The default data paths are:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Git share mode publishes compressed JSONL table snapshots and normalized Markdow
 `publish --tag NAME` creates an immutable checkpoint. `subscribe` and `update` merge snapshots without deleting local-only rows by default; `--restore` requests exact replacement, and `--retain-revisions` saves replaced local payloads.
 
 Secrets are not included in Markdown or git share snapshots.
+Structured signed-file URL credentials are removed from these outgoing
+projections; ordinary link parameters and private local raw recovery payloads
+are retained.
 
 ## Configuration
 

--- a/internal/markdown/export.go
+++ b/internal/markdown/export.go
@@ -109,6 +109,34 @@ func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.
 	if err != nil {
 		return "", store.BlockCoverage{}, err
 	}
+	projected, err := notiontext.ExportFields(map[string]string{
+		"url": page.URL, "title": page.Title, "icon": page.Icon, "cover": page.Cover,
+		"properties_json": page.PropertiesJSON, "raw_json": page.RawJSON,
+	})
+	if err != nil {
+		return "", store.BlockCoverage{}, err
+	}
+	page.URL, page.Title = projected["url"], projected["title"]
+	page.Icon, page.Cover = projected["icon"], projected["cover"]
+	page.PropertiesJSON, page.RawJSON = projected["properties_json"], projected["raw_json"]
+	for i := range blocks {
+		projected, err := notiontext.ExportFields(map[string]string{
+			"text": blocks[i].Text, "properties_json": blocks[i].PropertiesJSON,
+			"raw_json": blocks[i].RawJSON, "content_json": blocks[i].ContentJSON,
+			"format_json": blocks[i].FormatJSON,
+		})
+		if err != nil {
+			return "", store.BlockCoverage{}, err
+		}
+		blocks[i].Text, blocks[i].PropertiesJSON = projected["text"], projected["properties_json"]
+	}
+	for i := range comments {
+		projected, err := notiontext.ExportFields(map[string]string{"text": comments[i].Text, "raw_json": comments[i].RawJSON})
+		if err != nil {
+			return "", store.BlockCoverage{}, err
+		}
+		comments[i].Text = projected["text"]
+	}
 	spaceSlug := notiontext.Slug(spaceName)
 	titleSlug := maxSlug(notiontext.Slug(page.Title), 96)
 	name := fmt.Sprintf("%s-%s.md", titleSlug, notiontext.ShortID(page.ID))
@@ -491,7 +519,11 @@ func renderBlock(b *strings.Builder, block store.Block, depth int) {
 	case "numbered_list", "numbered_list_item":
 		writeLine(b, indent+"1. "+fallback(text, block.Type))
 	case "to_do", "to_do_item":
-		writeLine(b, indent+"- [ ] "+fallback(text, block.Type))
+		mark := " "
+		if todoChecked(block) {
+			mark = "x"
+		}
+		writeLine(b, indent+"- ["+mark+"] "+fallback(text, block.Type))
 	case "quote":
 		writeLine(b, "> "+fallback(text, block.Type))
 	case "code":
@@ -513,6 +545,24 @@ func renderBlock(b *strings.Builder, block store.Block, depth int) {
 			writeLine(b, fmt.Sprintf("[%s]", block.Type))
 		}
 	}
+}
+
+func todoChecked(block store.Block) bool {
+	var properties map[string]json.RawMessage
+	if json.Unmarshal([]byte(block.PropertiesJSON), &properties) != nil {
+		return false
+	}
+	var checked bool
+	if json.Unmarshal(properties["checked"], &checked) == nil {
+		return checked
+	}
+	if block.Source == store.SourceDesktop {
+		var value [][]string
+		if json.Unmarshal(properties["checked"], &value) == nil && len(value) > 0 && len(value[0]) > 0 {
+			return value[0][0] == "Yes"
+		}
+	}
+	return false
 }
 
 func writeLine(b *strings.Builder, line string) {

--- a/internal/markdown/export.go
+++ b/internal/markdown/export.go
@@ -110,7 +110,8 @@ func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.
 		return "", store.BlockCoverage{}, err
 	}
 	projected, err := notiontext.ExportFields(map[string]string{
-		"url": page.URL, "title": page.Title, "icon": page.Icon, "cover": page.Cover,
+		"source": page.Source,
+		"url":    page.URL, "title": page.Title, "icon": page.Icon, "cover": page.Cover,
 		"properties_json": page.PropertiesJSON, "raw_json": page.RawJSON,
 	})
 	if err != nil {
@@ -121,7 +122,8 @@ func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.
 	page.PropertiesJSON, page.RawJSON = projected["properties_json"], projected["raw_json"]
 	for i := range blocks {
 		projected, err := notiontext.ExportFields(map[string]string{
-			"text": blocks[i].Text, "properties_json": blocks[i].PropertiesJSON,
+			"source": blocks[i].Source,
+			"text":   blocks[i].Text, "properties_json": blocks[i].PropertiesJSON,
 			"raw_json": blocks[i].RawJSON, "content_json": blocks[i].ContentJSON,
 			"format_json": blocks[i].FormatJSON,
 		})
@@ -131,7 +133,7 @@ func (e Exporter) writePage(ctx context.Context, paths pathResolver, page store.
 		blocks[i].Text, blocks[i].PropertiesJSON = projected["text"], projected["properties_json"]
 	}
 	for i := range comments {
-		projected, err := notiontext.ExportFields(map[string]string{"text": comments[i].Text, "raw_json": comments[i].RawJSON})
+		projected, err := notiontext.ExportFields(map[string]string{"source": comments[i].Source, "text": comments[i].Text, "raw_json": comments[i].RawJSON})
 		if err != nil {
 			return "", store.BlockCoverage{}, err
 		}

--- a/internal/markdown/todo_test.go
+++ b/internal/markdown/todo_test.go
@@ -1,0 +1,33 @@
+package markdown
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestRenderTodoCheckedState(t *testing.T) {
+	for _, tc := range []struct {
+		name, source, properties, marker string
+	}{
+		{"api checked", store.SourceAPI, `{"checked":true}`, "[x]"},
+		{"api unchecked", store.SourceAPI, `{"checked":false}`, "[ ]"},
+		{"desktop checked", store.SourceDesktop, `{"checked":[["Yes"]]}`, "[x]"},
+		{"desktop unchecked", store.SourceDesktop, `{"checked":[["No"]]}`, "[ ]"},
+		{"missing", store.SourceAPI, `{}`, "[ ]"},
+		{"malformed", store.SourceAPI, `{"checked":"true"}`, "[ ]"},
+		{"invalid", store.SourceDesktop, `{`, "[ ]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			block := store.Block{Type: "to_do", Text: "task", Source: tc.source, PropertiesJSON: tc.properties}
+			var first, second strings.Builder
+			renderBlock(&first, block, 1)
+			renderBlock(&second, block, 1)
+			want := "  - " + tc.marker + " task\n\n"
+			if first.String() != want || second.String() != want {
+				t.Fatalf("rendered %q / %q, want %q", first.String(), second.String(), want)
+			}
+		})
+	}
+}

--- a/internal/notionapi/api.go
+++ b/internal/notionapi/api.go
@@ -71,7 +71,7 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 	}
 	c.HTTP = httpClientOrDefault(c.HTTP)
 	var s Summary
-	if err := st.DeferPageFTS(ctx, func() error {
+	if err := func() error {
 		started := time.Now()
 		c.tracePhase("users", "started", started)
 		users, err := c.listUsers(ctx)
@@ -143,7 +143,7 @@ func (c Client) Sync(ctx context.Context, st *store.Store) (Summary, error) {
 			return err
 		}
 		return nil
-	}); err != nil {
+	}(); err != nil {
 		return s, err
 	}
 	return s, nil
@@ -178,7 +178,7 @@ func nextListCursor(resp obj, seen map[string]bool, op string) (string, bool, er
 	}
 	cursor, _ := resp["next_cursor"].(string)
 	if cursor == "" {
-		return "", false, nil
+		return "", false, fmt.Errorf("%s has_more without a nonempty string next_cursor", op)
 	}
 	// Cursors are opaque. Compare exact values without limiting healthy listings.
 	if seen[cursor] {
@@ -295,21 +295,28 @@ func (c Client) ingestPage(ctx context.Context, st *store.Store, page obj, opts 
 	if p.Title == "" {
 		p.Title = "Untitled"
 	}
-	if opts.FetchBlocks {
-		if err := st.ClearSyncState(ctx, SourceName, "page_blocks", p.ID); err != nil {
-			return 0, 0, nil, err
+	if err := writePageBatch(ctx, st, func() error {
+		if opts.FetchBlocks {
+			if err := st.ClearSyncState(ctx, SourceName, "page_blocks", p.ID); err != nil {
+				return err
+			}
 		}
-	}
-	if err := st.UpsertPage(ctx, p); err != nil {
+		if err := st.UpsertPage(ctx, p); err != nil {
+			return err
+		}
+		if !p.Alive {
+			if _, err := st.RetireSourcePageBlocks(ctx, SourceName, p.ID); err != nil {
+				return err
+			}
+			if _, err := st.RetireSourcePageComments(ctx, SourceName, p.ID); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
 		return 0, 0, nil, err
 	}
 	if !p.Alive {
-		if _, err := st.RetireSourcePageBlocks(ctx, SourceName, p.ID); err != nil {
-			return 0, 0, nil, err
-		}
-		if _, err := st.RetireSourcePageComments(ctx, SourceName, p.ID); err != nil {
-			return 0, 0, nil, err
-		}
 		return 0, 0, nil, nil
 	}
 	var blocks, comments int
@@ -320,17 +327,6 @@ func (c Client) ingestPage(ctx context.Context, st *store.Store, page obj, opts 
 			return 0, 0, nil, err
 		}
 		warnings = append(warnings, blockWarnings...)
-		// Only mark this page's block sync complete when every children batch
-		// was fetched; a skipped batch (e.g. an unsupported block type) must
-		// leave it unmarked so notion-mcp's automatic repair pass (see
-		// automaticCandidates in internal/notionmcp/client.go, which treats an
-		// unset api/page_blocks "complete" state as a repair candidate) keeps
-		// retrying it instead of the gap going untracked.
-		if len(blockWarnings) == 0 {
-			if err := st.SetSyncState(ctx, SourceName, "page_blocks", p.ID, "complete"); err != nil {
-				return 0, 0, nil, err
-			}
-		}
 	}
 	if opts.FetchComments {
 		comments, err = c.ingestComments(ctx, st, p.ID, p.SpaceID)
@@ -454,11 +450,24 @@ func (c Client) walkBlocks(ctx context.Context, st *store.Store, pageID, parentI
 	// re-fetch — otherwise a page that previously synced cleanly loses its
 	// existing content the moment it gains one unfetchable block.
 	if len(warnings) == 0 {
-		if _, err := st.RetireSourcePageBlocksNotSyncedAt(ctx, SourceName, pageID, syncedAt); err != nil {
+		if err := writePageBatch(ctx, st, func() error {
+			if _, err := st.RetireSourcePageBlocksNotSyncedAt(ctx, SourceName, pageID, syncedAt); err != nil {
+				return err
+			}
+			return st.SetSyncState(ctx, SourceName, "page_blocks", pageID, "complete")
+		}); err != nil {
 			return count, warnings, err
 		}
 	}
 	return count, warnings, nil
+}
+
+// Each committed API batch includes its search projection; network requests
+// and recursive traversal must remain outside this transaction.
+func writePageBatch(ctx context.Context, st *store.Store, write func() error) error {
+	return st.WithTransaction(ctx, func() error {
+		return st.DeferPageFTS(ctx, write)
+	})
 }
 
 func (c Client) walkBlocksAt(ctx context.Context, st *store.Store, pageID, parentID, spaceID string, syncedAt int64) (int, []string, error) {
@@ -481,6 +490,8 @@ func (c Client) walkBlocksAt(ctx context.Context, st *store.Store, pageID, paren
 			}
 			return count, warnings, err
 		}
+		var batch []store.Block
+		var children []string
 		for _, item := range asSlice(resp["results"]) {
 			m, ok := item.(map[string]any)
 			if !ok {
@@ -492,7 +503,7 @@ func (c Client) walkBlocksAt(ctx context.Context, st *store.Store, pageID, paren
 			text := notiontext.Plain(typeBody)
 			raw := notiontext.MarshalRaw(block)
 			displayOrder++
-			if err := st.UpsertBlock(ctx, store.Block{
+			batch = append(batch, store.Block{
 				ID:             block.string("id"),
 				PageID:         pageID,
 				SpaceID:        spaceID,
@@ -508,18 +519,29 @@ func (c Client) walkBlocksAt(ctx context.Context, st *store.Store, pageID, paren
 				Source:         SourceName,
 				RawJSON:        raw,
 				SyncedAt:       syncedAt,
-			}); err != nil {
+			})
+			if shouldFetchBlockChildren(block) {
+				children = append(children, block.string("id"))
+			}
+		}
+		if err := writePageBatch(ctx, st, func() error {
+			for _, block := range batch {
+				if err := st.UpsertBlock(ctx, block); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			return count, warnings, err
+		}
+		count += len(batch)
+		for _, childID := range children {
+			n, childWarnings, err := c.walkBlocksAt(ctx, st, pageID, childID, spaceID, syncedAt)
+			warnings = append(warnings, childWarnings...)
+			if err != nil {
 				return count, warnings, err
 			}
-			count++
-			if shouldFetchBlockChildren(block) {
-				n, childWarnings, err := c.walkBlocksAt(ctx, st, pageID, block.string("id"), spaceID, syncedAt)
-				warnings = append(warnings, childWarnings...)
-				if err != nil {
-					return count, warnings, err
-				}
-				count += n
-			}
+			count += n
 		}
 		next, more, err := nextListCursor(resp, seen, "Notion block children")
 		if err != nil {

--- a/internal/notionapi/api_test.go
+++ b/internal/notionapi/api_test.go
@@ -1139,7 +1139,7 @@ func TestNextListCursorRejectsRepeatedAndEmpty(t *testing.T) {
 		t.Fatalf("repeated: more=%v err=%v", more, err)
 	}
 	next, more, err = nextListCursor(obj{"has_more": true, "next_cursor": ""}, seen, "Notion users/list")
-	if err != nil || more || next != "" {
+	if err == nil || more || next != "" {
 		t.Fatalf("empty cursor: next=%q more=%v err=%v", next, more, err)
 	}
 	next, more, err = nextListCursor(obj{"has_more": false, "next_cursor": "abc"}, seen, "Notion users/list")

--- a/internal/notionapi/fts_consistency_test.go
+++ b/internal/notionapi/fts_consistency_test.go
@@ -1,0 +1,112 @@
+package notionapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestAPIFailureKeepsCommittedSearchConsistent(t *testing.T) {
+	for _, retired := range []bool{false, true} {
+		t.Run(map[bool]string{false: "updated", true: "retired"}[retired], func(t *testing.T) {
+			ctx := context.Background()
+			st, err := store.Open(filepath.Join(t.TempDir(), "archive.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			if err := st.UpsertPage(ctx, store.Page{ID: "first", Title: "obsoleteword", Alive: true, Source: SourceName, SyncedAt: 1}); err != nil {
+				t.Fatal(err)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/users":
+					_ = json.NewEncoder(w).Encode(obj{"results": []any{}, "has_more": false})
+				case "/search":
+					_ = json.NewEncoder(w).Encode(obj{"results": []any{
+						obj{"id": "first", "archived": retired, "properties": obj{"title": obj{"type": "title", "title": []any{obj{"plain_text": "currentword"}}}}},
+						obj{"id": "second"},
+					}, "has_more": false})
+				case "/blocks/second/children":
+					http.Error(w, "synthetic upstream failure", http.StatusTeapot)
+				case "/blocks/first/children", "/comments":
+					_ = json.NewEncoder(w).Encode(obj{"results": []any{}, "has_more": false})
+				default:
+					t.Errorf("unexpected path %s", r.URL.Path)
+					http.Error(w, "unexpected", http.StatusBadRequest)
+				}
+			}))
+			defer server.Close()
+			_, err = (Client{BaseURL: server.URL, Token: "test", HTTP: server.Client()}).Sync(ctx, st)
+			if err == nil || !strings.Contains(err.Error(), "418") {
+				t.Fatalf("lost upstream error: %v", err)
+			}
+			old, err := st.Search(ctx, "obsoleteword", 10)
+			if err != nil || len(old) != 0 {
+				t.Fatalf("stale search after failure: %v %v", old, err)
+			}
+			current, err := st.Search(ctx, "currentword", 10)
+			want := 1
+			if retired {
+				want = 0
+			}
+			if err != nil || len(current) != want {
+				t.Fatalf("committed search: %v %v, want %d", current, err, want)
+			}
+			if err := st.DeferPageFTS(ctx, func() error { return nil }); err != nil {
+				t.Fatal(err)
+			}
+			complete, err := st.HasSyncState(ctx, SourceName, "workspace", "default")
+			if err != nil || complete {
+				t.Fatalf("failed workspace marked complete: %v %v", complete, err)
+			}
+		})
+	}
+}
+
+func TestAPIBatchRollsBackOnFTSFailureOrCancellation(t *testing.T) {
+	for _, cancelBatch := range []bool{false, true} {
+		t.Run(map[bool]string{false: "fts failure", true: "cancellation"}[cancelBatch], func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			st, err := store.Open(filepath.Join(t.TempDir(), "archive.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			page := store.Page{ID: "page", Title: "before", Alive: true, Source: SourceName, SyncedAt: 1}
+			if err := st.UpsertPage(ctx, page); err != nil {
+				t.Fatal(err)
+			}
+			if !cancelBatch {
+				if _, err := st.DB().ExecContext(ctx, "drop table page_fts"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err = writePageBatch(ctx, st, func() error {
+				page.Title, page.SyncedAt = "after", 2
+				if err := st.UpsertPage(ctx, page); err != nil {
+					return err
+				}
+				if cancelBatch {
+					cancel()
+				}
+				return nil
+			})
+			if err == nil || (cancelBatch && !errors.Is(err, context.Canceled)) {
+				t.Fatalf("expected batch error, got %v", err)
+			}
+			var title string
+			if err := st.DB().QueryRowContext(context.Background(), "select title from pages where id = 'page'").Scan(&title); err != nil || title != "before" {
+				t.Fatalf("canonical batch did not roll back: %q, %v", title, err)
+			}
+		})
+	}
+}

--- a/internal/notionapi/incomplete_cursor_test.go
+++ b/internal/notionapi/incomplete_cursor_test.go
@@ -1,0 +1,57 @@
+package notionapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestIncompleteCursorPreservesUnseenBlocks(t *testing.T) {
+	for _, cursor := range []string{"missing", "null", `""`, "42"} {
+		t.Run(cursor, func(t *testing.T) {
+			ctx := context.Background()
+			st, err := store.Open(filepath.Join(t.TempDir(), "archive.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			if err := st.UpsertPage(ctx, store.Page{ID: "page", Title: "test", Alive: true, Source: SourceName, SyncedAt: 1}); err != nil {
+				t.Fatal(err)
+			}
+			if err := st.UpsertBlock(ctx, store.Block{ID: "unseen", PageID: "page", ParentID: "page", Type: "paragraph", Text: "retained", Alive: true, Source: SourceName, SyncedAt: 1}); err != nil {
+				t.Fatal(err)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				response := obj{"results": []any{}, "has_more": true}
+				if cursor != "missing" {
+					var value any
+					if err := json.Unmarshal([]byte(cursor), &value); err != nil {
+						t.Error(err)
+					}
+					response["next_cursor"] = value
+				}
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+			client := Client{BaseURL: server.URL, Token: "test-auth-token", HTTP: server.Client()}
+			_, _, _, err = client.ingestPage(ctx, st, obj{"id": "page"}, ingestPageOptions{FetchBlocks: true})
+			if err == nil || !strings.Contains(err.Error(), "next_cursor") {
+				t.Fatalf("wanted invalid continuation, got %v", err)
+			}
+			var alive int
+			if err := st.DB().QueryRowContext(ctx, "select alive from blocks where id = 'unseen'").Scan(&alive); err != nil || alive != 1 {
+				t.Fatalf("unseen child retired: alive=%d err=%v", alive, err)
+			}
+			complete, err := st.HasSyncState(ctx, SourceName, "page_blocks", "page")
+			if err != nil || complete {
+				t.Fatalf("incomplete page marked complete: %v, %v", complete, err)
+			}
+		})
+	}
+}

--- a/internal/notiontext/desktop_export_test.go
+++ b/internal/notiontext/desktop_export_test.go
@@ -1,0 +1,181 @@
+package notiontext
+
+import (
+	"encoding/json"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func desktopExportEnvelope() map[string]any {
+	return map[string]any{
+		"id": "block", "space_id": "space", "type": "file",
+		"properties": `{}`, "content": `[]`, "format": `{}`, "collection_id": "",
+		"created_time": json.Number("9007199254740993"), "last_edited_time": json.Number("9007199254740993"),
+		"parent_id": "page", "parent_table": "block", "alive": json.Number("1"),
+	}
+}
+
+func exportJSON(t *testing.T, value any) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func TestExportFieldsDesktopEnvelopes(t *testing.T) {
+	u := url.URL{Scheme: "https", Host: "files.example", Path: "/attachment"}
+	u.RawQuery = url.Values{"X-Amz-Signature": {"redacted"}, "X-Amz-Credential": {"placeholder"}, "download": {"1"}}.Encode()
+	properties := `{"number":9223372036854775807,"fraction":0.10000000000000001,"raw_json":"ordinary text","format":"not JSON"}`
+	format := exportJSON(t, map[string]any{"display_source": u.String(), "number": json.Number("-9223372036854775808")})
+	block := desktopExportEnvelope()
+	block["properties"], block["format"] = properties, format
+	for name, envelope := range map[string]map[string]any{
+		"block": block,
+		"collection": {
+			"id": "collection", "space_id": "space", "parent_id": "page", "parent_table": "block",
+			"name": "Collection", "schema": properties, "format": format,
+		},
+		"comment": {
+			"id": "comment", "parent_id": "page", "space_id": "space", "text": "ordinary text",
+			"content": format, "created_by_id": "user", "created_time": json.Number("9007199254740993"),
+			"last_edited_time": json.Number("9007199254740993"), "alive": json.Number("1"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw := exportJSON(t, envelope)
+			fallback := exportJSON(t, map[string]any{
+				"Source": "desktop", "RawJSON": raw, "PropertiesJSON": properties, "FormatJSON": format,
+				"DisplayOrder": json.Number("9007199254740993"),
+			})
+			for field, payload := range map[string]string{"raw_json": raw, "payload_json": fallback} {
+				t.Run(field, func(t *testing.T) {
+					input := map[string]string{"source": "desktop", field: payload}
+					got, err := ExportFields(input)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if input[field] != payload {
+						t.Fatal("export changed the local payload")
+					}
+					if strings.Contains(got[field], "X-Amz-") {
+						t.Fatal("Desktop capability survived export")
+					}
+					projected, err := decodeExportJSON(got[field])
+					if err != nil {
+						t.Fatal(err)
+					}
+					if field == "payload_json" {
+						wrapper := projected.(map[string]any)
+						if wrapper["DisplayOrder"] != json.Number("9007199254740993") {
+							t.Fatal("fallback integer rounded")
+						}
+						projected, err = decodeExportJSON(wrapper["RawJSON"].(string))
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+					object := projected.(map[string]any)
+					if !reflect.DeepEqual(object["created_time"], envelope["created_time"]) {
+						t.Fatal("outer integer rounded")
+					}
+					for _, column := range desktopEnvelopeJSONFields(envelope) {
+						value, err := decodeExportJSON(object[column].(string))
+						if err != nil {
+							t.Fatal(err)
+						}
+						if column == "properties" || column == "schema" {
+							want, err := decodeExportJSON(properties)
+							if err != nil || !reflect.DeepEqual(value, want) {
+								t.Fatalf("ordinary properties/numbers changed: %v", err)
+							}
+						}
+						if column == "format" || (name == "comment" && column == "content") {
+							fields := value.(map[string]any)
+							if fields["display_source"] != "https://files.example/attachment?download=1" ||
+								fields["number"] != json.Number("-9223372036854775808") {
+								t.Fatal("invalid Desktop URL or numeric projection")
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestExportFieldsDesktopContextIsNotUserJSON(t *testing.T) {
+	for _, source := range []string{"", "api", "notion-mcp", "desktop"} {
+		for _, shape := range []string{"known", "extra property", "missing column", "missing identity", "nested property"} {
+			if source == "desktop" && shape == "known" {
+				continue
+			}
+			t.Run(source+"/"+shape, func(t *testing.T) {
+				envelope := desktopExportEnvelope()
+				envelope["format"] = "arbitrary user text, not JSON"
+				switch shape {
+				case "extra property":
+					envelope["user_property"] = true
+				case "missing column":
+					delete(envelope, "parent_table")
+				case "missing identity":
+					envelope["id"] = ""
+				case "nested property":
+					envelope = map[string]any{"custom": envelope}
+				}
+				raw := exportJSON(t, envelope)
+				got, err := ExportFields(map[string]string{"source": source, "raw_json": raw})
+				if err != nil {
+					t.Fatalf("reinterpreted an unrecognized envelope: %v", err)
+				}
+				before, err := decodeExportJSON(raw)
+				if err != nil {
+					t.Fatal(err)
+				}
+				after, err := decodeExportJSON(got["raw_json"])
+				if err != nil || !reflect.DeepEqual(before, after) {
+					t.Fatalf("changed arbitrary user content: %v", err)
+				}
+			})
+		}
+	}
+	envelope := desktopExportEnvelope()
+	envelope["properties"] = exportJSON(t, map[string]any{
+		"format": "not JSON", "raw_json": "not JSON", "payload_json": "not JSON",
+		"custom": desktopExportEnvelope(),
+	})
+	raw := exportJSON(t, envelope)
+	if _, err := ExportFields(map[string]string{"source": "desktop", "raw_json": raw}); err != nil {
+		t.Fatalf("provider properties were treated as storage columns: %v", err)
+	}
+}
+
+func TestExportFieldsDesktopMalformedColumnsFailClosed(t *testing.T) {
+	for _, column := range []string{"properties", "content", "format"} {
+		for _, value := range []any{`{`, `{} {}`, json.Number("1")} {
+			t.Run(column+"/"+exportJSON(t, value), func(t *testing.T) {
+				envelope := desktopExportEnvelope()
+				envelope[column] = value
+				raw := exportJSON(t, envelope)
+				for field, payload := range map[string]string{
+					"raw_json":     raw,
+					"payload_json": exportJSON(t, map[string]string{"Source": "desktop", "RawJSON": raw}),
+				} {
+					if _, err := ExportFields(map[string]string{"source": "desktop", field: payload}); err == nil {
+						t.Fatal("malformed known Desktop column exported")
+					}
+				}
+			})
+		}
+	}
+	for _, empty := range []any{nil, ""} {
+		envelope := desktopExportEnvelope()
+		envelope["format"] = empty
+		if _, err := ExportFields(map[string]string{"source": "desktop", "raw_json": exportJSON(t, envelope)}); err != nil {
+			t.Fatalf("absent Desktop column rejected: %v", err)
+		}
+	}
+}

--- a/internal/notiontext/export.go
+++ b/internal/notiontext/export.go
@@ -1,0 +1,161 @@
+package notiontext
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// ExportFields projects provider records without modifying their local recovery
+// payloads. Only structured URL fields identify capabilities; arbitrary text is
+// changed only when it repeats a capability found in that same record.
+func ExportFields(fields map[string]string) (map[string]string, error) {
+	replacements := map[string]string{}
+	var replacementKeys []string
+	replaceText := false
+	var visit func(any, string, bool) (any, error)
+	visit = func(value any, key string, storageFields bool) (any, error) {
+		switch v := value.(type) {
+		case map[string]any:
+			for k, child := range v {
+				clean, err := visit(child, k, storageFields && key == "")
+				if err != nil {
+					return nil, err
+				}
+				v[k] = clean
+			}
+		case []any:
+			for i, child := range v {
+				clean, err := visit(child, key, false)
+				if err != nil {
+					return nil, err
+				}
+				v[i] = clean
+			}
+		case string:
+			field := strings.ReplaceAll(strings.ToLower(key), "_", "")
+			switch field {
+			case "rawjson", "propertiesjson", "contentjson", "formatjson", "payloadjson":
+				if !storageFields {
+					break
+				}
+				if strings.TrimSpace(v) == "" {
+					return v, nil
+				}
+				dec := json.NewDecoder(strings.NewReader(v))
+				dec.UseNumber()
+				var nested any
+				if err := dec.Decode(&nested); err != nil {
+					return nil, errors.New("cannot sanitize malformed provider JSON for export")
+				}
+				if err := dec.Decode(new(any)); err != io.EOF {
+					return nil, errors.New("cannot sanitize trailing provider JSON for export")
+				}
+				// Only source fallback payloads wrap storage columns. Provider
+				// objects can contain arbitrary user property names.
+				nested, err := visit(nested, "", field == "payloadjson")
+				if err != nil {
+					return nil, err
+				}
+				raw, err := json.Marshal(nested)
+				return string(raw), err
+			case "url", "icon", "cover", "displaysource":
+				clean, err := exportFileURL(v)
+				if err != nil {
+					return nil, err
+				}
+				if clean != v {
+					replacements[v] = clean
+				}
+				v = clean
+			}
+			if replaceText && strings.Contains(v, "://") {
+				for _, from := range replacementKeys {
+					v = strings.ReplaceAll(v, from, replacements[from])
+				}
+			}
+			return v, nil
+		}
+		return value, nil
+	}
+	projected := make(map[string]string, len(fields))
+	for key, value := range fields {
+		projected[key] = value
+	}
+	// A second pass covers derived text encountered before its structured URL.
+	for range 2 {
+		for key, value := range projected {
+			clean, err := visit(value, key, true)
+			if err != nil {
+				return nil, err
+			}
+			projected[key] = clean.(string)
+		}
+		if !replaceText {
+			for from := range replacements {
+				replacementKeys = append(replacementKeys, from)
+			}
+			// Longest first avoids replacing a URL prefix before the full URL.
+			sort.Slice(replacementKeys, func(i, j int) bool {
+				if len(replacementKeys[i]) == len(replacementKeys[j]) {
+					return replacementKeys[i] < replacementKeys[j]
+				}
+				return len(replacementKeys[i]) > len(replacementKeys[j])
+			})
+			replaceText = true
+		}
+	}
+	return projected, nil
+}
+
+func exportFileURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		// A bad path escape must not hide valid query credentials.
+		_, rawQuery, _ := strings.Cut(raw, "?")
+		rawQuery, _, _ = strings.Cut(rawQuery, "#")
+		query, _ := url.ParseQuery(rawQuery)
+		v4, v2, cloudfront := fileURLSignatures(query)
+		if strings.Contains(strings.ToLower(raw), "x-amz-") || v4 || v2 || cloudfront {
+			return "", errors.New("cannot sanitize malformed signed file URL for export")
+		}
+		return raw, nil
+	}
+	if (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		return raw, nil
+	}
+	query, err := url.ParseQuery(u.RawQuery)
+	v4, v2, cloudfront := fileURLSignatures(query)
+	if err != nil {
+		if strings.Contains(strings.ToLower(u.RawQuery), "x-amz-") || v4 || v2 || cloudfront {
+			return "", errors.New("cannot sanitize malformed signed file URL for export")
+		}
+		return raw, nil
+	}
+	if !v4 && !v2 && !cloudfront {
+		return raw, nil
+	}
+	for key := range query {
+		k := strings.ToLower(key)
+		if (v4 && strings.HasPrefix(k, "x-amz-")) ||
+			(v2 && (k == "signature" || k == "awsaccesskeyid" || k == "expires" || k == "security-token")) ||
+			(cloudfront && (k == "signature" || k == "key-pair-id" || k == "policy" || k == "expires")) {
+			query.Del(key)
+		}
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}
+
+func fileURLSignatures(query url.Values) (v4, v2, cloudfront bool) {
+	lower := map[string]bool{}
+	for key := range query {
+		lower[strings.ToLower(key)] = true
+	}
+	return lower["x-amz-signature"] || lower["x-amz-credential"] || lower["x-amz-security-token"],
+		lower["signature"] && lower["awsaccesskeyid"],
+		lower["signature"] && lower["key-pair-id"]
+}

--- a/internal/notiontext/export.go
+++ b/internal/notiontext/export.go
@@ -38,25 +38,51 @@ func ExportFields(fields map[string]string) (map[string]string, error) {
 		case string:
 			field := strings.ReplaceAll(strings.ToLower(key), "_", "")
 			switch field {
-			case "rawjson", "propertiesjson", "contentjson", "formatjson", "payloadjson":
+			case "rawjson", "propertiesjson", "contentjson", "formatjson", "schemajson", "payloadjson":
 				if !storageFields {
 					break
 				}
 				if strings.TrimSpace(v) == "" {
 					return v, nil
 				}
-				dec := json.NewDecoder(strings.NewReader(v))
-				dec.UseNumber()
-				var nested any
-				if err := dec.Decode(&nested); err != nil {
-					return nil, errors.New("cannot sanitize malformed provider JSON for export")
+				nested, err := decodeExportJSON(v)
+				if err != nil {
+					return nil, err
 				}
-				if err := dec.Decode(new(any)); err != io.EOF {
-					return nil, errors.New("cannot sanitize trailing provider JSON for export")
+				if field == "rawjson" && fields["source"] == "desktop" {
+					if envelope, ok := nested.(map[string]any); ok {
+						// Desktop's SQLite json_object envelopes retain TEXT JSON
+						// columns as strings. Only those known outer shapes qualify.
+						for _, column := range desktopEnvelopeJSONFields(envelope) {
+							if envelope[column] == nil {
+								continue
+							}
+							raw, ok := envelope[column].(string)
+							if !ok {
+								return nil, errors.New("cannot sanitize invalid Desktop JSON column for export")
+							}
+							if strings.TrimSpace(raw) == "" {
+								continue
+							}
+							content, err := decodeExportJSON(raw)
+							if err != nil {
+								return nil, err
+							}
+							content, err = visit(content, "", false)
+							if err != nil {
+								return nil, err
+							}
+							encoded, err := json.Marshal(content)
+							if err != nil {
+								return nil, err
+							}
+							envelope[column] = string(encoded)
+						}
+					}
 				}
 				// Only source fallback payloads wrap storage columns. Provider
 				// objects can contain arbitrary user property names.
-				nested, err := visit(nested, "", field == "payloadjson")
+				nested, err = visit(nested, "", field == "payloadjson")
 				if err != nil {
 					return nil, err
 				}
@@ -109,6 +135,51 @@ func ExportFields(fields map[string]string) (map[string]string, error) {
 		}
 	}
 	return projected, nil
+}
+
+func decodeExportJSON(raw string) (any, error) {
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, errors.New("cannot sanitize malformed provider JSON for export")
+	}
+	if err := dec.Decode(new(any)); err != io.EOF {
+		return nil, errors.New("cannot sanitize trailing provider JSON for export")
+	}
+	return value, nil
+}
+
+func desktopEnvelopeJSONFields(envelope map[string]any) []string {
+	if id, ok := envelope["id"].(string); !ok || id == "" {
+		return nil
+	}
+	// Match the complete column lists emitted by notiondesktop ingestion, not
+	// arbitrary provider objects or user properties named "format"/"content".
+	for _, shape := range []struct {
+		keys    string
+		columns []string
+	}{
+		{"id space_id type properties content collection_id created_time last_edited_time parent_id parent_table alive format", []string{"properties", "content", "format"}},
+		{"id space_id parent_id parent_table name schema format", []string{"schema", "format"}},
+		{"id parent_id space_id text content created_by_id created_time last_edited_time alive", []string{"content"}},
+	} {
+		keys := strings.Fields(shape.keys)
+		if len(envelope) != len(keys) {
+			continue
+		}
+		matches := true
+		for _, key := range keys {
+			if _, ok := envelope[key]; !ok {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return shape.columns
+		}
+	}
+	return nil
 }
 
 func exportFileURL(raw string) (string, error) {

--- a/internal/notiontext/export_test.go
+++ b/internal/notiontext/export_test.go
@@ -1,0 +1,110 @@
+package notiontext
+
+import (
+	"encoding/json"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestExportFieldsSignedFiles(t *testing.T) {
+	signedURL := url.URL{Scheme: "https", Host: "files.example", Path: "/file", Fragment: "part"}
+	signedURL.RawQuery = url.Values{"X-Amz-Signature": {"redacted"}, "X-Amz-Credential": {"placeholder"}, "download": {"1"}}.Encode()
+	signed := signedURL.String()
+	clean := "https://files.example/file?download=1#part"
+	ordinary := url.URL{Scheme: "https", Host: "example.test", RawQuery: url.Values{"token": {"ordinary"}, "query": {"keep"}}.Encode()}
+	properties := `{"file":{"url":"` + signed + `"},"number":9007199254740993,"ordinary":{"url":"` + ordinary.String() + `"}}`
+	envelope, err := json.Marshal(map[string]string{"PropertiesJSON": properties, "RawJSON": properties, "Text": "attachment <" + signed + ">"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := map[string]string{"payload_json": string(envelope), "properties_json": properties, "text": "attachment <" + signed + ">", "unrelated": "user text token=unchanged"}
+	got, err := ExportFields(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["text"] != "attachment <"+clean+">" || got["unrelated"] != original["unrelated"] || original["properties_json"] != properties {
+		t.Fatalf("projection changed unrelated/source fields: %#v", got)
+	}
+	for _, key := range []string{"payload_json", "properties_json"} {
+		if strings.Contains(got[key], "X-Amz-") || !strings.Contains(got[key], "9007199254740993") || !strings.Contains(got[key], "token=ordinary") {
+			t.Fatalf("invalid projection %s: %s", key, got[key])
+		}
+	}
+	for _, input := range []string{`{"file":{"url":`, `{} {}`} {
+		if _, err := ExportFields(map[string]string{"raw_json": input}); err == nil {
+			t.Fatal("malformed protected JSON exported")
+		}
+	}
+}
+
+func TestExportFileURLPreservesOrdinaryQueries(t *testing.T) {
+	ordinary := url.URL{Scheme: "https", Host: "example.test", RawQuery: url.Values{"token": {"keep"}, "signature": {"ordinary"}}.Encode()}
+	for _, raw := range []string{ordinary.String(), "https://example.test/?q=%zz", "ordinary text X-Amz-Signature=keep"} {
+		got, err := exportFileURL(raw)
+		if err != nil || got != raw {
+			t.Fatalf("ordinary value changed: %q %q %v", raw, got, err)
+		}
+	}
+}
+
+func TestExportFileURLLegacySignatures(t *testing.T) {
+	for _, identity := range []string{"AWSAccessKeyId", "Key-Pair-Id"} {
+		t.Run(identity, func(t *testing.T) {
+			u := url.URL{Scheme: "https", Host: "files.example", Path: "/file", Fragment: "part"}
+			u.RawQuery = url.Values{"Signature": {"redacted"}, identity: {"placeholder"}, "Expires": {"123"}, "download": {"1"}}.Encode()
+			got, err := exportFileURL(u.String())
+			if err != nil || got != "https://files.example/file?download=1#part" {
+				t.Fatalf("legacy signature projection: %q %v", got, err)
+			}
+			for _, raw := range []string{
+				strings.Replace(u.String(), "?", "?broken=%zz&", 1),
+				strings.Replace(u.String(), "/file", "/%zz", 1),
+			} {
+				if _, err := exportFileURL(raw); err == nil {
+					t.Fatal("malformed signed URL exported unchanged")
+				}
+				body, err := json.Marshal(map[string]string{"url": raw})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := ExportFields(map[string]string{"raw_json": string(body)}); err == nil {
+					t.Fatal("structured projection accepted malformed signed URL")
+				}
+			}
+		})
+	}
+}
+
+func TestExportFieldsPreservesUserPropertyNames(t *testing.T) {
+	properties := `{"raw_json":[["ordinary text"]],"payload_json":"not JSON","PropertiesJSON":{"raw_json":"also ordinary"},"number":9007199254740993}`
+	envelope, err := json.Marshal(map[string]string{"PropertiesJSON": properties, "RawJSON": properties})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ExportFields(map[string]string{"properties_json": properties, "payload_json": string(envelope)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var projectedEnvelope map[string]string
+	if err := json.Unmarshal([]byte(got["payload_json"]), &projectedEnvelope); err != nil {
+		t.Fatal(err)
+	}
+	decode := func(raw string) any {
+		t.Helper()
+		decoder := json.NewDecoder(strings.NewReader(raw))
+		decoder.UseNumber()
+		var value any
+		if err := decoder.Decode(&value); err != nil {
+			t.Fatal(err)
+		}
+		return value
+	}
+	want := decode(properties)
+	for _, raw := range []string{got["properties_json"], projectedEnvelope["PropertiesJSON"], projectedEnvelope["RawJSON"]} {
+		if !reflect.DeepEqual(decode(raw), want) {
+			t.Fatalf("user properties changed: %s", raw)
+		}
+	}
+}

--- a/internal/share/desktop_export_test.go
+++ b/internal/share/desktop_export_test.go
@@ -1,0 +1,252 @@
+package share
+
+import (
+	"compress/gzip"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/markdown"
+	"github.com/openclaw/notcrawl/internal/notiondesktop"
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestShareDesktopEnvelopesWithoutChangingArchive(t *testing.T) {
+	for _, mode := range []string{"fresh", "existing archive", "Desktop fallback"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			source := desktopSignedExportFixture(t)
+			archive := filepath.Join(t.TempDir(), "archive.db")
+			st, err := store.Open(archive)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := st.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			summary, err := notiondesktop.Ingest(ctx, st, source, t.TempDir(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if summary.Pages != 1 || summary.Blocks != 2 || summary.RawRecords != 2 ||
+				summary.Collections != 1 || summary.Comments != 1 {
+				t.Fatalf("incomplete ingestion fixture: %+v", summary)
+			}
+			if mode == "existing archive" {
+				// Export already-persisted Desktop envelopes without reingestion.
+				if err := st.Close(); err != nil {
+					t.Fatal(err)
+				}
+				st, err = store.Open(archive)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if mode == "Desktop fallback" {
+				if err := st.UpsertPage(ctx, store.Page{
+					ID: "page", SpaceID: "space", Title: "API page", Source: store.SourceAPI,
+					Alive: true, PropertiesJSON: `{}`, RawJSON: `{}`, SyncedAt: store.NowMS(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if err := st.UpsertBlock(ctx, store.Block{
+					ID: "file", PageID: "page", SpaceID: "space", ParentID: "page",
+					Type: "paragraph", Text: "API body", Source: store.SourceAPI,
+					Alive: true, PropertiesJSON: `{}`, RawJSON: `{}`, SyncedAt: store.NowMS(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if err := st.UpsertComment(ctx, store.Comment{
+					ID: "comment", PageID: "page", ParentID: "page", SpaceID: "space",
+					Text: "API comment", Source: store.SourceAPI, Alive: true,
+					RawJSON: `{}`, SyncedAt: store.NowMS(),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				var count int
+				if err := st.DB().QueryRowContext(ctx, `SELECT count(*) FROM record_sources
+					WHERE source = 'desktop' AND payload_json LIKE '%X-Amz-%'`).Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				if count != 3 {
+					t.Fatalf("expected three retained Desktop fallback payloads, got %d", count)
+				}
+			}
+			before := desktopRecoveryPayloads(t, st)
+			md := t.TempDir()
+			exported, err := (markdown.Exporter{Store: st, Dir: md}).Export(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(exported.Files) != 1 {
+				t.Fatalf("Markdown fixture exported %d files", len(exported.Files))
+			}
+			for _, path := range exported.Files {
+				body, err := os.ReadFile(path)
+				if err != nil || strings.Contains(string(body), "X-Amz-") {
+					t.Fatalf("Markdown retained a signed capability: %v", err)
+				}
+			}
+			repo := t.TempDir()
+			result, err := Publish(ctx, st, PublishOptions{RepoPath: repo, MarkdownDir: md})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Manifest.RecordSources == nil {
+				t.Fatal("fallback payload export missing")
+			}
+			tables := append(append([]TableManifest{}, result.Manifest.Tables...), *result.Manifest.RecordSources)
+			for _, table := range tables {
+				payload := readDesktopExportTable(t, filepath.Join(repo, table.Path))
+				if strings.Contains(payload, "X-Amz-") {
+					t.Fatalf("table %s retained a signed capability", table.Name)
+				}
+				if table.Name == "raw_records" || table.Name == "collections" {
+					for _, exact := range []string{"9223372036854775807", "0.10000000000000001", "ordinary user text"} {
+						if !strings.Contains(payload, exact) {
+							t.Fatalf("table %s changed exact numeric/user data %q", table.Name, exact)
+						}
+					}
+				}
+				if table.Name == "raw_records" && !strings.Contains(payload, "9007199254740993") {
+					t.Fatal("Desktop outer integer rounded")
+				}
+				if mode == "Desktop fallback" && table.Name == "record_sources" &&
+					!strings.Contains(payload, "9223372036854775807") {
+					t.Fatal("fallback payload lost exact numeric data")
+				}
+			}
+			publishedPages := 0
+			if err := filepath.WalkDir(filepath.Join(repo, "pages"), func(path string, entry fs.DirEntry, err error) error {
+				if err != nil || entry.IsDir() {
+					return err
+				}
+				body, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				if strings.Contains(string(body), "X-Amz-") {
+					t.Fatal("published Markdown retained a signed capability")
+				}
+				publishedPages++
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if publishedPages != len(exported.Files) {
+				t.Fatal("published Markdown copy missing")
+			}
+			if after := desktopRecoveryPayloads(t, st); !reflect.DeepEqual(before, after) {
+				t.Fatal("export changed local Desktop recovery bytes")
+			}
+		})
+	}
+}
+
+func desktopSignedExportFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "desktop.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	if _, err := db.Exec(`CREATE TABLE block (
+		id TEXT PRIMARY KEY, space_id TEXT, type TEXT, properties TEXT, content TEXT,
+		collection_id TEXT, created_time INTEGER, last_edited_time INTEGER, parent_id TEXT,
+		parent_table TEXT, alive INTEGER, format TEXT);
+		CREATE TABLE collection (
+		id TEXT PRIMARY KEY, space_id TEXT, parent_id TEXT, parent_table TEXT,
+		name TEXT, schema TEXT, format TEXT, alive INTEGER);
+		CREATE TABLE comment (
+		id TEXT PRIMARY KEY, parent_id TEXT, space_id TEXT, text TEXT, content TEXT,
+		created_by_id TEXT, created_time INTEGER, last_edited_time INTEGER, alive INTEGER);`); err != nil {
+		t.Fatal(err)
+	}
+	u := url.URL{Scheme: "https", Host: "files.example", Path: "/attachment"}
+	u.RawQuery = url.Values{"X-Amz-Signature": {"redacted"}, "X-Amz-Credential": {"placeholder"}, "download": {"1"}}.Encode()
+	format, err := json.Marshal(map[string]string{"display_source": u.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	properties := `{"title":[["Files"]],"number":9223372036854775807,"fraction":0.10000000000000001,"format":"ordinary user text","raw_json":"not JSON"}`
+	if _, err := db.Exec(`INSERT INTO block VALUES
+		('page','space','page',?,'["file"]','',9007199254740993,9007199254740993,'','',1,?),
+		('file','space','file',?,'[]','',9007199254740993,9007199254740993,'page','block',1,?)`,
+		properties, string(format), properties, string(format)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO collection VALUES
+		('collection','space','page','block','Collection',?,?,1)`, properties, string(format)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO comment VALUES
+		('comment','page','space','Comment',?,'user',1,1,1)`, string(format)); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func desktopRecoveryPayloads(t *testing.T, st *store.Store) map[string]string {
+	t.Helper()
+	rows, err := st.DB().Query(`SELECT 'page:' || id, raw_json FROM pages
+		UNION ALL SELECT 'block:' || id, raw_json FROM blocks
+		UNION ALL SELECT 'collection:' || id, raw_json FROM collections
+		UNION ALL SELECT 'comment:' || id, raw_json FROM comments
+		UNION ALL SELECT 'raw:' || source || ':' || record_table || ':' || record_id, raw_json FROM raw_records
+		UNION ALL SELECT 'fallback:' || source || ':' || record_table || ':' || record_id, COALESCE(payload_json,'') FROM record_sources`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	signed := false
+	for rows.Next() {
+		var key, raw string
+		if err := rows.Scan(&key, &raw); err != nil {
+			t.Fatal(err)
+		}
+		out[key] = raw
+		signed = signed || strings.Contains(raw, "X-Amz-")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !signed {
+		t.Fatal("local recovery fixture contains no original signed URL")
+	}
+	return out
+}
+
+func readDesktopExportTable(t *testing.T, path string) string {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	body, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openclaw/crawlkit/mirror"
 	cksnapshot "github.com/openclaw/crawlkit/snapshot"
+	"github.com/openclaw/notcrawl/internal/notiontext"
 	"github.com/openclaw/notcrawl/internal/store"
 )
 
@@ -514,6 +515,19 @@ func encodeExportRows(ctx context.Context, db *sql.DB, table string, w io.Writer
 		row := map[string]any{}
 		for i, col := range cols {
 			row[col] = exportValue(values[i])
+		}
+		fields := map[string]string{}
+		for key, value := range row {
+			if text, ok := value.(string); ok {
+				fields[key] = text
+			}
+		}
+		projected, err := notiontext.ExportFields(fields)
+		if err != nil {
+			return 0, err
+		}
+		for key, value := range projected {
+			row[key] = value
 		}
 		if err := enc.Encode(row); err != nil {
 			return 0, err

--- a/internal/share/signed_files_test.go
+++ b/internal/share/signed_files_test.go
@@ -1,0 +1,96 @@
+package share
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/markdown"
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestShareProjectsSignedFilesWithoutChangingArchive(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "source.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	signedURL := url.URL{Scheme: "https", Host: "files.example", Path: "/file"}
+	signedURL.RawQuery = url.Values{"X-Amz-Signature": {"redacted"}, "X-Amz-Credential": {"placeholder"}, "download": {"1"}}.Encode()
+	signed := signedURL.String()
+	properties := `{"files":{"type":"files","files":[{"type":"file","file":{"url":"` + signed + `"}}]}}`
+	raw := `{"properties":` + properties + `,"number":9007199254740993}`
+	page := store.Page{ID: "page", Title: "Files", Alive: true, Source: store.SourceAPI, SyncedAt: 1, PropertiesJSON: properties, RawJSON: raw}
+	if err := st.UpsertPage(ctx, page); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertRawRecord(ctx, store.RawRecord{Source: store.SourceAPI, RecordTable: "page", RecordID: "page", RawJSON: raw, SyncedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertBlock(ctx, store.Block{ID: "file", PageID: "page", ParentID: "page", Type: "file", Text: signed, Alive: true, Source: store.SourceAPI, SyncedAt: 1, PropertiesJSON: `{"file":{"url":"` + signed + `"}}`, RawJSON: raw}); err != nil {
+		t.Fatal(err)
+	}
+	md := t.TempDir()
+	exported, err := (markdown.Exporter{Store: st, Dir: md}).Export(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(exported.Files[0])
+	if err != nil || strings.Contains(string(body), "X-Amz-") {
+		t.Fatalf("Markdown retained capability: %s %v", body, err)
+	}
+	repo := t.TempDir()
+	result, err := Publish(ctx, st, PublishOptions{RepoPath: repo, MarkdownDir: md})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tables := append([]TableManifest{}, result.Manifest.Tables...)
+	if result.Manifest.RecordSources != nil {
+		tables = append(tables, *result.Manifest.RecordSources)
+	}
+	for _, table := range tables {
+		file, err := os.Open(filepath.Join(repo, table.Path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			file.Close()
+			t.Fatal(err)
+		}
+		payload, err := io.ReadAll(gz)
+		gz.Close()
+		file.Close()
+		if err != nil || strings.Contains(string(payload), "X-Amz-") {
+			t.Fatalf("table %s retained capability: %v", table.Name, err)
+		}
+		if table.Name == "pages" && !strings.Contains(string(payload), "9007199254740993") {
+			t.Fatal("numeric raw field changed")
+		}
+	}
+	dst, err := store.Open(filepath.Join(t.TempDir(), "destination.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	if _, err := Import(ctx, dst, repo); err != nil {
+		t.Fatal(err)
+	}
+	var localRaw, importedRaw string
+	if err := st.DB().QueryRowContext(ctx, "select raw_json from pages where id = 'page'").Scan(&localRaw); err != nil {
+		t.Fatal(err)
+	}
+	if err := dst.DB().QueryRowContext(ctx, "select raw_json from pages where id = 'page'").Scan(&importedRaw); err != nil {
+		t.Fatal(err)
+	}
+	if localRaw != raw || strings.Contains(importedRaw, "X-Amz-") || !json.Valid([]byte(importedRaw)) {
+		t.Fatal("projection mutated local data or broke import")
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes cases where a failed or incomplete API sync could leave committed content and search results inconsistent, outgoing archives could retain structured signed-file URL credentials, and completed todos could lose their checked state in Markdown.

## Why This Change Was Made

- Commit API content batches and their search index consistently, retaining searchable progress when a later request fails.
- Reject incomplete continuation metadata without retiring unseen blocks or claiming complete coverage.
- Remove structured signed-file URL capabilities from outgoing shares and Markdown, including malformed signed URL handling, while preserving ordinary link parameters, arbitrary user properties and local raw recovery data.
- Cover known Desktop raw envelopes and retained fallback copies, including existing archives, without reinterpreting arbitrary JSON-looking user text or rounding exact numeric values.
- Preserve completed API and Desktop todo checkboxes in Markdown.

The dependency remains the published `crawlkit v0.14.9`. No schema, dependency pin, provider-write or deletion-policy change is included. Missing API search results are not treated as deletion evidence.

## User Impact

Previously committed content stays searchable after partial failures. Incomplete pagination does not retire unseen content. Outgoing projections omit signed-file credentials without changing local recovery payloads, and completed todos remain checked.

Malformed protected provider JSON or signed file URLs that cannot be safely sanitized stop `export-md` and `publish` without deleting local records. This fail-closed compatibility behavior is explicitly accepted. The README now explains consistent private backups, read-only diagnosis without exposing payloads or signed URLs, separate-path reimport when sources remain available, and the limits of historical recovery. Failed exports may leave partial or stale output; atomic rollback and manual publication are not promised.

The broader Markdown/transclusion request at https://github.com/openclaw/notcrawl/issues/101 and the omitted-page reconciliation policy request at https://github.com/openclaw/notcrawl/issues/126 remain separate and unresolved by this PR. Neither should be automatically closed.

## Evidence

- Exact reviewed source and documentation: `b1fb14f08a37171eb690477f3d84861baac90cb6`, with verified SSH-signed commits. Its only changes from the approved runtime at `7219bcc5de7f988ba536a343ba717b6f5d49f4f2` are README recovery guidance and the corresponding changelog entry.
- Published-pin full `go test`, `go build`, `go vet`, module verification, and tidy-with-no-module-diff gates previously passed at `36cc80fe2e33055721ac8dbe3f697a1f20e482d7` with Go 1.27.1 and `GOWORK=off`.
- The new Desktop ingestion-to-publication regression fails on that prior head in fresh, existing-archive, and fallback cases. All three cases pass after this repair, inspecting every final compressed table and published Markdown copy and checking unchanged local recovery bytes.
- Repair validation: `go test -mod=readonly -p 1 -count=1 -timeout=120s ./internal/notiontext ./internal/markdown ./internal/share` and vet on those packages passed (110 tests/subtests, no skips). Independent structured source review found no actionable issues.
- Regressions cover partial API failures, FTS rollback/cancellation, incomplete cursors, signed-file export/import projection, unchanged local raw data and user properties, malformed URLs, and todo rendering.
- Validation used bounded resources, temporary homes/stores and synthetic fixtures without real providers or native credentials.
- Hosted runtime checks passed at `7219bcc5de7f988ba536a343ba717b6f5d49f4f2`: https://github.com/openclaw/notcrawl/actions/runs/34287966414.
- The documentation-only follow-up passed `git diff --check` and independent structured prose review with no findings. New-head hosted checks remain required. No unchanged full local suites were rerun for prose; native/live-provider and consumer race validation are not claimed.
