### PR TITLE
chore: update CrawlKit to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update CrawlKit to v0.15.0 while retaining the Go 1.27.1 minimum.
 - Document fail-closed export errors for malformed protected JSON, private read-only diagnosis, separate-path recovery limits, and partial or stale output after failure.
 - Sanitize signed file URLs inside known Desktop raw JSON envelopes and fallback copies during export, including existing archives, without changing local recovery bytes or exact numeric values.
 - Remove structured signed-file URL credentials from outgoing shares and Markdown without changing local raw recovery payloads or ordinary link parameters.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 require (
 	github.com/alecthomas/kong v1.16.1
-	github.com/openclaw/crawlkit v0.14.9
+	github.com/openclaw/crawlkit v0.15.0
 	modernc.org/sqlite v1.58.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.9 h1:nlLxcBvwtgVw5WehmjQCrRyfIYrDyQbJ3zPyKhUeta0=
-github.com/openclaw/crawlkit v0.14.9/go.mod h1:jGtyzzrIcBPzj0fTiP2I+/LcfTMsfT/o9Zx8jh0HMDc=
+github.com/openclaw/crawlkit v0.15.0 h1:KAmdew2UQPZm/gOfqiLw/WhhDY7Y2UZj0EcgQ5s7dl4=
+github.com/openclaw/crawlkit v0.15.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
## What Problem This Solves

Updates Notcrawl to the published CrawlKit v0.15.0 after the archive-consistency and export-recovery changes landed.

## Why This Change Was Made

The complete selected-module change is CrawlKit v0.14.9 to v0.15.0. Only the module pin, its checksums, and the changelog change. Go 1.27.1 and the selected SQLite v1.58.0/libc v1.75.6 pair remain unchanged, with no module replacements.

## User Impact

Notcrawl consumes the published shared archive fixes without changing source policy, its independent snapshot format, schema, recovery guidance, or release configuration. The separate work tracked in https://github.com/openclaw/notcrawl/issues/101 and https://github.com/openclaw/notcrawl/issues/126 remains open; this pin does not claim to complete either issue.

## Evidence

- Signed pin commit: `0985fb73f8fbcb1f7fcc0a5f81444829e5973cff`, based on landed source `c1b8b95052014618f45dce02f0c1b8d87e3ca6b8`.
- Go 1.27.1, `GOWORK=off`: tidy-no-diff, module verification, all-package build and vet passed.
- Focused share/store/API/Markdown/CLI regressions passed: 110 test/subtest results in six packages, no skips or failures. Required cases include Desktop ingestion through final export, FTS transaction consistency, incomplete-cursor preservation, stable Markdown behavior, and machine-readable commands.
- Built-binary `--help`, `--version`, `metadata --json`, `status --json`, and `tui --json` passed output, exit, and temporary-file inventory checks.
- Pinned govulncheck v1.7.0 completed against a fresh frozen advisory database: 170 OSV records retained, zero called/imported/module findings. Config, selected graph, complete JSON, and normal completion were checked. Scope is Linux AMD64, CGO disabled, Go 1.27.1, default tags; no native or universal clearance is claimed.
- Focused review passed. Validation used isolated temporary homes/stores, read-only source/dependencies, denied network, and bounded resources.
- Final-head [hosted CI](https://github.com/openclaw/notcrawl/actions/runs/34293300565) passed full Linux and Windows test suites, builds, lint, dependencies, and snapshot checks; CodeQL and secret scanning also passed. The unchanged workflow has no dedicated race or coverage step, and no such new-pin result is claimed. This stays a draft for bounded final review; no app release is requested.
