### PR TITLE
fix(share): publish archives without Markdown pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Git share mode publishes compressed JSONL table snapshots and normalized Markdow
 
 `publish --tag NAME` creates an immutable checkpoint. `subscribe` and `update` merge snapshots without deleting local-only rows by default; `--restore` requests exact replacement, and `--retain-revisions` saves replaced local payloads.
 
+An archive with no Markdown pages can still be published and subscribed to.
+
 Secrets are not included in Markdown or git share snapshots.
 Structured signed-file URL credentials are removed from these outgoing
 projections; ordinary link parameters and private local raw recovery payloads

--- a/internal/share/empty_publish_test.go
+++ b/internal/share/empty_publish_test.go
@@ -1,0 +1,57 @@
+package share
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/notcrawl/internal/store"
+)
+
+func TestPublishCommitsEmptyMarkdownArchive(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	repo := filepath.Join(t.TempDir(), "share")
+	for i := 0; i < 2; i++ {
+		if _, err := Publish(ctx, st, PublishOptions{RepoPath: repo, Commit: true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files := gitOutputForTest(t, repo, "ls-tree", "-r", "--name-only", "HEAD")
+	if !strings.Contains(files, "manifest.json") || !strings.Contains(files, "data/pages.jsonl.gz") {
+		t.Fatalf("snapshot is incomplete: %s", files)
+	}
+	if got := gitOutputForTest(t, repo, "status", "--porcelain"); got != "" {
+		t.Fatalf("publish left uncommitted changes: %s", got)
+	}
+}
+
+func TestPublishCommitsRemovalOfLastMarkdownPage(t *testing.T) {
+	ctx := context.Background()
+	st, md := snapshotStoreForTest(t, ctx, "Page", "fixture")
+	defer st.Close()
+	repo := filepath.Join(t.TempDir(), "share")
+	if _, err := Publish(ctx, st, PublishOptions{RepoPath: repo, MarkdownDir: md, Commit: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "notes.txt"), []byte("unrelated staged notes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitForTest(t, repo, "add", "notes.txt")
+	if _, err := Publish(ctx, st, PublishOptions{RepoPath: repo, Commit: true}); err != nil {
+		t.Fatal(err)
+	}
+	files := gitOutputForTest(t, repo, "ls-tree", "-r", "--name-only", "HEAD")
+	if strings.Contains(files, ".md") || strings.Contains(files, "notes.txt") {
+		t.Fatalf("unexpected committed file: %s", files)
+	}
+	if got := gitOutputForTest(t, repo, "diff", "--cached", "--name-only"); strings.TrimSpace(got) != "notes.txt" {
+		t.Fatalf("unrelated staged change was altered: %s", got)
+	}
+}

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -1007,6 +1007,16 @@ func commitGenerated(ctx context.Context, repoPath, message string) (bool, error
 	if message == "" {
 		message = "archive: notcrawl snapshot"
 	}
+	// Git cannot commit an empty directory pathspec. Keep pages addressable
+	// even before the first page, or after the last generated page is removed.
+	marker, err := os.OpenFile(filepath.Join(repoPath, "pages", ".gitkeep"), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err == nil {
+		if err := marker.Close(); err != nil {
+			return false, err
+		}
+	} else if !errors.Is(err, os.ErrExist) {
+		return false, err
+	}
 	return mirror.CommitPaths(ctx, mirror.Options{RepoPath: repoPath}, message, []string{"manifest.json", "data", "pages"})
 }
 


### PR DESCRIPTION
Publishing a new archive with no Markdown pages fails at `git commit -- manifest.json data pages`: Git cannot commit an empty directory pathspec. Keep an empty, non-overwriting marker in the generated pages directory so empty snapshots can be committed, cloned, and updated.

Regression coverage checks initial/repeated empty publication, removal of the last Markdown page, and preservation of unrelated staged files. The real built CLI reproduces the pathspec failure on main and passes initial publish, repeat publish, subscribe, and SQL inspection with this fix. All fixtures are synthetic and local.

P0–P2 local autoreview is clean. The share suite passes after correcting the test helper's trailing-newline assertion; other packages passed in the full run. Exact-head CI and committed-branch review are recorded in the proof comment.

Independent branch off main. The changelog bullet is collected only in #131; merge this and #130 before #131. No release or tag is created.
