### PR TITLE
chore: release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.1 - 2026-09-11
 
 **Highlights:** More reliable archive sharing and searchable progress after interrupted syncs.
 


### PR DESCRIPTION
Date the 0.6.1 changelog for September 11, retaining the existing Highlights line, ordered notes, and contributor credit.

The release contains the landed snapshot integer-precision and empty-share fixes, archive consistency/export repairs, and dependency refresh. Runtime code is unchanged by this PR; the unified workflow injects version 0.6.1 into release binaries, as it did for 0.6.0.

The full prepared candidate already passed native CLI/TUI proof, tests, dependency checks, and snapshot builds. Local P0–P2 autoreview is clean. Require green CI on the release commit before the authorized unified release workflow creates the tag or publishes.
